### PR TITLE
Output to either a single file or one file per-module

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,10 +5,10 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:815bcec01073eddedf69690d8b1edc936fa7e9c0ee9bced01149111af0a033fa"
+content_hash = "sha256:c2175586c4dc6f7ba91b52866c1197257e0b0d6527900839ee4b88b1b73e5a5c"
 
 [[metadata.targets]]
-requires_python = ">=3.9"
+requires_python = ">=3.10"
 
 [[package]]
 name = "astroid"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Chris Riccomini", email = "criccomini@apache.org"},
 ]
 dependencies = ["docstring-parser-fork>=0.0.12"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "CC-0"}
 

--- a/src/python_docstring_markdown/__init__.py
+++ b/src/python_docstring_markdown/__init__.py
@@ -1,3 +1,3 @@
-from .generate import crawl
+from .generate import crawl_package
 
-__all__ = ["crawl"]
+__all__ = ["crawl_package"]

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -396,6 +396,20 @@ class MarkdownRenderer(Renderer):
             lines.append("```python")
             lines.append(signature)
             lines.append("```")
+        if doc.attrs:
+            lines.append("**Attributes:**")
+            lines.append("")
+            for attr in doc.attrs:
+                attr_line = f"- `{attr.arg_name}`"
+                if attr.type_name:
+                    attr_line += f" (**{attr.type_name}**)"
+                attr_line += f": {attr.description}"
+                if attr.default:
+                    attr_line += f" (default: `{attr.default}`)"
+                if attr.is_optional:
+                    attr_line += " (optional)"
+                lines.append(attr_line)
+            lines.append("")
         if doc.params:
             lines.append("**Parameters:**")
             lines.append("")
@@ -404,6 +418,10 @@ class MarkdownRenderer(Renderer):
                 if param.type_name:
                     param_line += f" (**{param.type_name}**)"
                 param_line += f": {param.description}"
+                if param.default:
+                    param_line += f" (default: `{param.default}`)"
+                if param.is_optional:
+                    param_line += " (optional)"
                 lines.append(param_line)
             lines.append("")
         if doc.examples:

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -473,6 +473,20 @@ class MarkdownRenderer:
             # Write the index file table of contents linking to each module
             (output_path / "index.md").write_text("\n".join(lines), encoding="utf8")
 
+    def render_constant(self, const: Constant, level: int = 2) -> list[str]:
+        lines: list[str] = []
+        header_prefix = "#" * level
+        type_str = f": {const.type}" if const.type else ""
+        # Constant header with an HTML anchor.
+        lines.append(f'<a name="{self.anchor(const.fully_qualified_name)}"></a>')
+        lines.append(f"{header_prefix} 🆅 {const.fully_qualified_name}")
+        lines.append("")
+        lines.append("```python")
+        lines.append(f"{const.name}{type_str} = {const.value}")
+        lines.append("```")
+        lines.append("")
+        return lines
+
     def render_module(
         self, module: Module, level: int = 2, is_one_file: bool = True
     ) -> list[str]:
@@ -496,7 +510,9 @@ class MarkdownRenderer:
         if module.constants:
             lines.append("- **Constants:**")
             for const in module.constants:
-                lines.append("  " * 1 + f"- 🆅 [{const.name}]({self.link(module, const)})")
+                lines.append(
+                    "  " * 1 + f"- 🆅 [{const.name}]({self.link(module, const)})"
+                )
         if module.functions:
             lines.append("- **Functions:**")
             for func in module.functions:
@@ -516,13 +532,7 @@ class MarkdownRenderer:
             lines.append(f"{header_prefix}# Constants")
             lines.append("")
             for const in module.constants:
-                type_str = f": {const.type}" if const.type else ""
-                lines.append(f"- **{const.name}**{type_str}")
-                lines.append("")
-                lines.append("```python")
-                lines.append(f"{const.name} = {const.value}")
-                lines.append("```")
-                lines.append("")
+                lines.extend(self.render_constant(const, level=level + 1))
         if module.functions:
             lines.append(f"{header_prefix}# Functions")
             lines.append("")

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -347,7 +347,7 @@ def crawl_package(package_path: Path) -> Package:
     return package
 
 
-def reformat_docstring(doc: docstring_parser.Docstring | None) -> str:
+def reformat_docstring(doc: docstring_parser.Docstring | None, signature: str | None = None) -> str:
     """
     Reformat the parsed docstring into Markdown.
     This implementation produces Markdown by concatenating the short and long descriptions,
@@ -362,13 +362,19 @@ def reformat_docstring(doc: docstring_parser.Docstring | None) -> str:
     if doc.long_description:
         lines.append(doc.long_description)
         lines.append("")
+    if signature:
+        lines.append("**Signature:**")
+        lines.append("")
+        lines.append("```python")
+        lines.append(signature)
+        lines.append("```")
     if doc.params:
         lines.append("**Parameters:**")
         lines.append("")
         for param in doc.params:
-            param_line = f"- **{param.arg_name}**"
+            param_line = f"- `{param.arg_name}`"
             if param.type_name:
-                param_line += f" ({param.type_name})"
+                param_line += f" (**{param.type_name}**)"
             param_line += f": {param.description}"
             lines.append(param_line)
         lines.append("")
@@ -377,14 +383,14 @@ def reformat_docstring(doc: docstring_parser.Docstring | None) -> str:
         lines.append("")
         ret_line = "- "
         if doc.returns.type_name:
-            ret_line += f"({doc.returns.type_name}) "
+            ret_line += f"(**{doc.returns.type_name}**) "
         ret_line += f"{doc.returns.description}"
         lines.append(ret_line)
         lines.append("")
     if doc.raises:
         lines.append("**Raises:**")
         for exception in doc.raises:
-            lines.append(f"- **{exception.type_name}**: {exception.description}")
+            lines.append(f"- (**{exception.type_name}**) {exception.description}")
         lines.append("")
     return "\n".join(lines).strip()
 
@@ -400,10 +406,9 @@ class Renderer:
 
 
 class MarkdownRenderer(Renderer):
-    def __init__(self, exclude_empty: bool = False):
+    def __init__(self):
         # List of tuples: (level, title, slug)
         self.toc: list[tuple[int, str, str]] = []
-        self.exclude_empty = exclude_empty
 
     @staticmethod
     def slugify(text: str) -> str:
@@ -427,7 +432,7 @@ class MarkdownRenderer(Renderer):
         """
         slug = self.slugify(item.name)
         self.toc.append((level, item.name, slug))
-        return [f'<a id="{slug}"></a>', f"{'#' * level} {item.name}"]
+        return [f'<a id="{slug}"></a>', f"{'#' * level} `{item.fully_qualified_name}`"]
 
     def render_toc(self) -> list[str]:
         """Render the table of contents based on the collected headers."""
@@ -435,11 +440,11 @@ class MarkdownRenderer(Renderer):
         title = "Table of Contents"
         slug = self.slugify(title)
         lines.append(f'<a id="{slug}"></a>')
-        lines.append(f"### {title}")
+        lines.append(f"**{title}**")
         lines.append("")
         for level, title, slug in self.toc:
             indent = "  " * (level - 1)
-            lines.append(f"{indent}- [{title}](#{slug})")
+            lines.append(f"{indent}- [`{title}`](#{slug})")
         lines.append("")
         return lines
 
@@ -448,14 +453,6 @@ class MarkdownRenderer(Renderer):
         lines = []
         # Render constant header with its fully qualified name.
         lines.extend(self.render_header(heading_level, const))
-        lines.append("")
-        lines.append("**Import**")
-        lines.append("")
-        lines.append(f"```python")
-        lines.append(f"import {const.fully_qualified_name}")
-        lines.append("```")
-        lines.append("")
-        lines.append("**Signature**")
         lines.append("")
         lines.append("```python")
         if const.type:
@@ -468,18 +465,10 @@ class MarkdownRenderer(Renderer):
 
     def render_function(self, func: Function, heading_level: int) -> list[str]:
         """Render a function or method to Markdown and return the lines as a list of strings."""
-        doc = reformat_docstring(func.docstring)
-        if self.exclude_empty and not doc:
-            return []
+        doc = reformat_docstring(func.docstring, func.signature)
         lines = []
         # For functions, override the header title to wrap the name in backticks.
         lines.extend(self.render_header(heading_level, func))
-        lines.append("")
-        lines.append("**Signature**")
-        lines.append("")
-        lines.append("```python")
-        lines.append(func.signature)
-        lines.append("```")
         lines.append("")
         if doc:
             lines.append(doc)
@@ -496,13 +485,7 @@ class MarkdownRenderer(Renderer):
         md = []
         md.extend(self.render_header(heading_level, cls))
         md.append("")
-        md.append("**Signature**")
-        md.append("")
-        md.append("```python")
-        md.append(cls.signature)
-        md.append("```")
-        md.append("")
-        doc = reformat_docstring(cls.docstring)
+        doc = reformat_docstring(cls.docstring, cls.signature)
         if doc:
             md.append(doc)
             md.append("")
@@ -599,7 +582,7 @@ def main() -> None:
         return
 
     package = crawl_package(package_dir)
-    renderer = MarkdownRenderer(exclude_empty=args.exclude_empty)
+    renderer = MarkdownRenderer()
     markdown_output = renderer.render(package)
     print(markdown_output)
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -169,7 +169,7 @@ def parse_function(
         path=file_path,
         name=node.name,
         fully_qualified_name=fq_name,
-        signature=signature,
+        signature=f"def {signature}:",
         docstring=parsed_doc,
     )
 
@@ -662,9 +662,12 @@ class MarkdownRenderer:
             lines.append("")
             ret_line = ""
             if doc.returns.type_name:
-                ret_line += f"`{doc.returns.type_name}`"
+                ret_line += f"`{doc.returns.type_name}`: "
             if doc.returns.description:
-                ret_line += f": {doc.returns.description}"
+                ret_line += f"{doc.returns.description}"
+            else:
+                # Trim the trailing colon if no description is provided.
+                ret_line = ret_line[:-2]
             lines.append(f"{indent_str}- {ret_line}")
             lines.append("")
         if doc.raises:

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -349,6 +349,7 @@ def crawl_package(package_path: Path) -> Package:
 
 # --- Renderer Classes ---
 
+
 class MarkdownRenderer:
     def __init__(self, include_private: bool = False):
         self.include_private = include_private
@@ -464,7 +465,11 @@ class MarkdownRenderer:
     def render_toc(self, root: Package | Module) -> list[str]:
         """Render the table of contents based on the collected headers."""
         lines = []
-        def render_item(level: int, item: Package | Module | Class | Function | Constant) -> None:
+
+        def render_item(
+            level: int,
+            item: Package | Module | Class | Function | Constant,
+        ) -> None:
             indent = "  " * (level - 1)
             slug = self.slugify(item.name)
             lines.append(f"{indent}- [`{item.name}`](#{slug})")
@@ -496,6 +501,7 @@ class MarkdownRenderer:
                         render_item(level + 1, func)
                 case _:
                     pass
+
         render_item(1, root)
         lines.append("")
         return lines
@@ -556,11 +562,15 @@ class MarkdownRenderer:
         md.extend(child_lines)
         return md
 
-    def render_module(self, module: Module) -> list[str]:
+    def render_module(self, module: Module, include_toc: bool = False) -> list[str]:
         """Render a module and its children."""
         lines = []
         lines.extend(self.render_header(2, module))
         lines.append("")
+
+        if include_toc:
+            lines.extend(self.render_toc(module))
+            lines.append("")
 
         module_doc = self.render_docstring(module.docstring)
         if module_doc:
@@ -588,26 +598,40 @@ class MarkdownRenderer:
         lines.extend(children_lines)
         return lines
 
-    def render_package(self, package: Package) -> list[str]:
+    def render_package(self, package: Package, include_toc: bool = False) -> list[str]:
         """
         Render the Package as a Markdown string.
         The table of contents is inserted immediately after the package header.
         """
-        package_header = self.render_header(1, package)
-        modules_lines: list[str] = []
+        lines = []
+        lines.extend(self.render_header(1, package))
+        lines.append("")
+        if include_toc:
+            lines.extend(self.render_toc(package))
+            lines.append("")
         for module in package.modules:
             rendered_module = self.render_module(module)
             if rendered_module:
-                modules_lines.extend(rendered_module)
-        toc_lines = self.render_toc(package)
-        final_lines = []
-        final_lines.extend(package_header)
-        final_lines.append("")
-        final_lines.extend(toc_lines)
-        final_lines.append("---")
-        final_lines.append("")
-        final_lines.extend(modules_lines)
-        return final_lines
+                lines.extend(rendered_module)
+        return lines
+
+    def render(self, root: Package | Module, include_toc: bool = False) -> list[str]:
+        """Render the root object as Markdown and return the lines as a list of strings."""
+        match root:
+            case Package():
+                return self.render_package(root, include_toc)
+            case Module():
+                return self.render_module(root, include_toc)
+            case _:
+                raise ValueError(f"Unsupported root type: {type(root)}")
+
+    def render_file(
+        self, root: Package | Module, path: Path, include_toc: bool = False
+    ) -> None:
+        """Render the root object as Markdown and write it to a file."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf8") as f:
+            f.write("\n".join(self.render(root, include_toc)))
 
 
 # --- Main function ---
@@ -632,7 +656,7 @@ def main() -> None:
 
     package = crawl_package(package_dir)
     renderer = MarkdownRenderer(include_private=args.include_private)
-    markdown_output = renderer.render_package(package)
+    markdown_output = renderer.render(package, True)
     print("\n".join(markdown_output))
 
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -351,8 +351,6 @@ def crawl_package(package_path: Path) -> Package:
 
 class MarkdownRenderer:
     def __init__(self, include_private: bool = False):
-        # List of tuples: (level, title, slug)
-        self.toc: list[tuple[int, str, str]] = []
         self.include_private = include_private
 
     @staticmethod
@@ -461,20 +459,44 @@ class MarkdownRenderer:
         Records the header in the TOC and returns a list of Markdown lines.
         """
         slug = self.slugify(item.name)
-        self.toc.append((level, item.name, slug))
         return [f'<a id="{slug}"></a>', f"{'#' * level} `{item.fully_qualified_name}`"]
 
-    def render_toc(self) -> list[str]:
+    def render_toc(self, root: Package | Module) -> list[str]:
         """Render the table of contents based on the collected headers."""
         lines = []
-        title = "Table of Contents"
-        slug = self.slugify(title)
-        lines.append(f'<a id="{slug}"></a>')
-        lines.append(f"**{title}**")
-        lines.append("")
-        for level, title, slug in self.toc:
+        def render_item(level: int, item: Package | Module | Class | Function | Constant) -> None:
             indent = "  " * (level - 1)
-            lines.append(f"{indent}- [`{title}`](#{slug})")
+            slug = self.slugify(item.name)
+            lines.append(f"{indent}- [`{item.name}`](#{slug})")
+            match item:
+                case Package(_):
+                    for module in item.modules:
+                        render_item(level + 1, module)
+                case Module(_):
+                    for constant in item.constants:
+                        if self.is_private(constant):
+                            continue
+                        render_item(level + 1, constant)
+                    for cls in item.classes:
+                        if self.is_private(cls):
+                            continue
+                        render_item(level + 1, cls)
+                    for func in item.functions:
+                        if self.is_private(func):
+                            continue
+                        render_item(level + 1, func)
+                case Class(_):
+                    for cls in item.classes:
+                        if self.is_private(cls):
+                            continue
+                        render_item(level + 1, cls)
+                    for func in item.functions:
+                        if self.is_private(func):
+                            continue
+                        render_item(level + 1, func)
+                case _:
+                    pass
+        render_item(1, root)
         lines.append("")
         return lines
 
@@ -571,14 +593,13 @@ class MarkdownRenderer:
         Render the Package as a Markdown string.
         The table of contents is inserted immediately after the package header.
         """
-        self.toc = []
         package_header = self.render_header(1, package)
         modules_lines: list[str] = []
         for module in package.modules:
             rendered_module = self.render_module(module)
             if rendered_module:
                 modules_lines.extend(rendered_module)
-        toc_lines = self.render_toc()
+        toc_lines = self.render_toc(package)
         final_lines = []
         final_lines.extend(package_header)
         final_lines.append("")

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -413,13 +413,17 @@ def crawl_package(package_path: Path, include_private: bool = False) -> Package:
         ):
             continue
         module = parse_module(file_path, package.fully_qualified_name, include_private)
-        modules.append(module)
+        if module.name == "__init__":
+            modules.append(module)
 
     # Add all modules to the package (including nested)
     while modules:
         module = modules.pop()
         package.modules.append(module)
         modules.extend(module.submodules)
+
+    # Sort package.modules by fully_qualified_name
+    package.modules.sort(key=lambda m: m.fully_qualified_name)
 
     return package
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -483,51 +483,37 @@ class MarkdownRenderer:
         lines: list[str] = []
         header_prefix = "#" * level
         # Module header with an HTML anchor.
-        lines.append(
-            f'{header_prefix} {module.fully_qualified_name} <a name="{self.anchor(module.fully_qualified_name)}"></a>'
-        )
+        lines.append(f'<a name="{self.anchor(module.fully_qualified_name)}"></a>')
+        lines.append(f"{header_prefix} {module.fully_qualified_name}")
         lines.append("")
 
         # Render module docstring details if available.
         if module.docstring:
             lines.extend(self.render_docstring(module.docstring))
+            lines.append("")
 
         # Second-level table of contents for this module.
-        lines.append(f"{header_prefix}# Contents")
-        lines.append("")
-        if module.exports:
-            lines.append(
-                f"- **[Exports](#{self.anchor(module.fully_qualified_name)}-exports)**"
-            )
-        if module.classes:
-            lines.append("- **Classes:**")
-            for cls in module.classes:
-                lines.extend(self.render_class_toc(module, cls, indent=1))
-        if module.functions:
-            lines.append("- **Functions:**")
-            for func in module.functions:
-                lines.append("  " * 1 + f"- [{func.name}]({self.link(module, func)})")
         if module.constants:
             lines.append("- **Constants:**")
             for const in module.constants:
                 lines.append("  " * 1 + f"- [{const.name}]({self.link(module, const)})")
+        if module.functions:
+            lines.append("- **Functions:**")
+            for func in module.functions:
+                lines.append("  " * 1 + f"- [{func.name}]({self.link(module, func)})")
+        if module.classes:
+            lines.append("- **Classes:**")
+            for cls in module.classes:
+                lines.extend(self.render_class_toc(module, cls, indent=1))
+        if module.exports:
+            lines.append(
+                f"- **[Exports](#{self.anchor(module.fully_qualified_name)}-exports)**"
+            )
         lines.append("")
 
         # Detailed sections.
-        if module.exports:
-            lines.append(
-                f'<a name="{self.anchor(module.fully_qualified_name)}-exports"></a>'
-            )
-            lines.append("#### Exports")
-            lines.append("")
-            for exp in module.exports:
-                # Hack since we have the fqn for a module as a string
-                fqn = f"{module.fully_qualified_name}.{exp}"
-                link = f"#{self.anchor(fqn)}" if is_one_file else f"{fqn}.md"
-                lines.append(f"- [`{exp}`]({link})")
-            lines.append("")
         if module.constants:
-            lines.append("#### Constants")
+            lines.append(f"{header_prefix}# Constants")
             lines.append("")
             for const in module.constants:
                 type_str = f": {const.type}" if const.type else ""
@@ -538,16 +524,28 @@ class MarkdownRenderer:
                 lines.append("```")
                 lines.append("")
         if module.functions:
-            lines.append("#### Functions")
+            lines.append(f"{header_prefix}# Functions")
             lines.append("")
             for func in module.functions:
                 lines.extend(self.render_function(func, level=level + 1))
             lines.append("")
         if module.classes:
-            lines.append("#### Classes")
+            lines.append(f"{header_prefix}# Classes")
             lines.append("")
             for cls in module.classes:
                 lines.extend(self.render_class_details(cls, level=level + 1))
+            lines.append("")
+        if module.exports:
+            lines.append(
+                f'<a name="{self.anchor(module.fully_qualified_name)}-exports"></a>'
+            )
+            lines.append(f"{header_prefix}# Exports")
+            lines.append("")
+            for exp in module.exports:
+                # Hack since we have the fqn for a module as a string
+                fqn = f"{module.fully_qualified_name}.{exp}"
+                link = f"#{self.anchor(fqn)}" if is_one_file else f"{fqn}.md"
+                lines.append(f"- [`{exp}`]({link})")
             lines.append("")
 
         return lines
@@ -570,9 +568,8 @@ class MarkdownRenderer:
         """
         lines: list[str] = []
         header_prefix = "#" * level
-        lines.append(
-            f'{header_prefix} {cls.fully_qualified_name} <a name="{self.anchor(cls.fully_qualified_name)}"></a>'
-        )
+        lines.append(f'<a name="{self.anchor(cls.fully_qualified_name)}"></a>')
+        lines.append(f"{header_prefix} {cls.fully_qualified_name}")
         lines.append("")
         lines.append("```python")
         lines.append(cls.signature)
@@ -601,9 +598,8 @@ class MarkdownRenderer:
         """
         lines: list[str] = []
         header_prefix = "#" * level
-        lines.append(
-            f'{header_prefix} {func.fully_qualified_name} <a name="{self.anchor(func.fully_qualified_name)}"></a>'
-        )
+        lines.append(f'<a name="{self.anchor(func.fully_qualified_name)}"></a>')
+        lines.append(f"{header_prefix} {func.fully_qualified_name}")
         lines.append("")
         lines.append("```python")
         lines.append(func.signature)
@@ -641,6 +637,17 @@ class MarkdownRenderer:
                     line += f": {param.description}"
                 lines.append(line)
             lines.append("")
+        if doc.attrs:
+            lines.append(f"{indent_str}**Attributes:**")
+            lines.append("")
+            for attr in doc.attrs:
+                line = f"{indent_str}- **{attr.arg_name}**"
+                if attr.type_name:
+                    line += f" (`{attr.type_name}`)"
+                if attr.description:
+                    line += f": {attr.description}"
+                lines.append(line)
+            lines.append("")
         if doc.returns:
             lines.append(f"{indent_str}**Returns:**")
             lines.append("")
@@ -658,17 +665,6 @@ class MarkdownRenderer:
                 lines.append(
                     f"{indent_str}- **{raise_item.type_name}**: {raise_item.description}"
                 )
-            lines.append("")
-        if doc.attrs:
-            lines.append(f"{indent_str}**Attributes:**")
-            lines.append("")
-            for attr in doc.attrs:
-                line = f"{indent_str}- **{attr.arg_name}**"
-                if attr.type_name:
-                    line += f" (`{attr.type_name}`)"
-                if attr.description:
-                    line += f": {attr.description}"
-                lines.append(line)
             lines.append("")
         return lines
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -35,7 +35,9 @@ class DocumentedItem(Protocol):
 class Package:
     path: Path
     name: str  # final name (directory name)
-    fully_qualified_name: str  # same as name for the top-level package
+    fully_qualified_name: str  # e.g. "mypkg" or "parent.child"
+    parent: Package | None = None
+    subpackages: list[Package] = field(default_factory=list)
     modules: list[Module] = field(default_factory=list)
 
 
@@ -66,6 +68,7 @@ class Class:
     # Can be either a module or another class (for nested classes)
     parent: Module | Class
     docstring: docstring_parser.Docstring | None = None
+    constants: list[Constant] = field(default_factory=list)  # New: class-level constants
     functions: list[Function] = field(default_factory=list)
     classes: list[Class] = field(default_factory=list)  # For nested classes
 
@@ -85,6 +88,7 @@ class Constant:
     path: Path
     name: str  # constant name
     fully_qualified_name: str  # e.g. foo.bar.MY_CONSTANT
+    parent: Module | Class
     value: str  # the string representation of the value
     type: str | None = None  # the constant's type, if available
 
@@ -169,7 +173,7 @@ def parse_function(
 
 
 def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> Class:
-    """Parse a class node into a Class dataclass instance and process its methods and nested classes."""
+    """Parse a class node into a Class dataclass instance and process its methods, constants, and nested classes."""
     raw_doc = ast.get_docstring(node)
     parsed_doc = docstring_parser.parse(raw_doc) if raw_doc else None
     fq_name = f"{parent.fully_qualified_name}.{node.name}"
@@ -186,10 +190,11 @@ def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> 
         signature=signature,
         parent=parent,
         docstring=parsed_doc,
+        constants=[],
         functions=[],
         classes=[],
     )
-    # Process methods and nested classes.
+    # Process methods, nested classes, and class-level constants.
     for child in node.body:
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
             method = parse_function(child, file_path, parent=cls)
@@ -197,6 +202,51 @@ def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> 
         elif isinstance(child, ast.ClassDef):
             nested_cls = parse_class(child, parent=cls, file_path=file_path)
             cls.classes.append(nested_cls)
+        elif isinstance(child, (ast.Assign, ast.AnnAssign)):
+            # Process assignments as class constants if they are ALL CAPS and not "__ALL__"
+            if isinstance(child, ast.Assign):
+                for target in child.targets:
+                    if (
+                        isinstance(target, ast.Name)
+                        and target.id.isupper()
+                        and target.id != "__ALL__"
+                    ):
+                        type_annotation = None
+                        if hasattr(child, "type_comment") and child.type_comment:
+                            type_annotation = child.type_comment
+                        value = ast.unparse(child.value)
+                        fq_const = f"{cls.fully_qualified_name}.{target.id}"
+                        constant = Constant(
+                            path=file_path,
+                            name=target.id,
+                            fully_qualified_name=fq_const,
+                            value=value,
+                            type=type_annotation,
+                            parent=cls,
+                        )
+                        cls.constants.append(constant)
+            elif isinstance(child, ast.AnnAssign):
+                if (
+                    isinstance(child.target, ast.Name)
+                    and child.target.id.isupper()
+                    and child.target.id != "__ALL__"
+                ):
+                    type_annotation = (
+                        ast.unparse(child.annotation) if child.annotation else None
+                    )
+                    value = (
+                        ast.unparse(child.value) if child.value is not None else "None"
+                    )
+                    fq_const = f"{cls.fully_qualified_name}.{child.target.id}"
+                    constant = Constant(
+                        path=file_path,
+                        name=child.target.id,
+                        fully_qualified_name=fq_const,
+                        value=value,
+                        type=type_annotation,
+                        parent=cls,
+                    )
+                    cls.constants.append(constant)
     return cls
 
 
@@ -235,7 +285,6 @@ def parse_module_constants(
     """
     for node in module_ast.body:
         if isinstance(node, (ast.Assign, ast.AnnAssign)):
-            # Process ast.Assign nodes (may have multiple targets).
             if isinstance(node, ast.Assign):
                 for target in node.targets:
                     if (
@@ -247,17 +296,17 @@ def parse_module_constants(
                         if hasattr(node, "type_comment") and node.type_comment:
                             type_annotation = node.type_comment
                         value = ast.unparse(node.value)
-                        fq_name = f"{module.fully_qualified_name}.{target.id}"
+                        fq_const = f"{module.fully_qualified_name}.{target.id}"
                         constant = Constant(
                             path=file_path,
                             name=target.id,
-                            fully_qualified_name=fq_name,
+                            fully_qualified_name=fq_const,
                             value=value,
                             type=type_annotation,
+                            parent=module,
                         )
                         module.constants.append(constant)
                         break
-            # Process annotated assignments.
             elif isinstance(node, ast.AnnAssign):
                 if (
                     isinstance(node.target, ast.Name)
@@ -270,13 +319,14 @@ def parse_module_constants(
                     value = (
                         ast.unparse(node.value) if node.value is not None else "None"
                     )
-                    fq_name = f"{module.fully_qualified_name}.{node.target.id}"
+                    fq_const = f"{module.fully_qualified_name}.{node.target.id}"
                     constant = Constant(
                         path=file_path,
                         name=node.target.id,
-                        fully_qualified_name=fq_name,
+                        fully_qualified_name=fq_const,
                         value=value,
                         type=type_annotation,
+                        parent=module,
                     )
                     module.constants.append(constant)
 
@@ -327,7 +377,7 @@ def parse_module(file_path: Path, package: Package) -> Module:
         classes=[],
         exports=[],
     )
-    if file_path.name == "__init__":
+    if file_path.name == "__init__.py":
         module.exports = parse_module_exports(module_ast)
     parse_module_constants(module_ast, module, file_path)
     parse_module_functions(module_ast, module, file_path)
@@ -335,15 +385,30 @@ def parse_module(file_path: Path, package: Package) -> Module:
     return module
 
 
-def crawl_package(package_path: Path) -> Package:
-    """Recursively crawl the package directory, parsing each .py file as a Module."""
+def crawl_package(package_path: Path, parent: Package | None = None) -> Package:
+    """Recursively crawl the package directory, parsing each .py file as a Module
+    and each subpackage as a Package.
+    A directory is considered a package if it contains an __init__.py file.
+    """
     pkg_name = package_path.name
+    fq_name = pkg_name if parent is None else f"{parent.fully_qualified_name}.{pkg_name}"
     package = Package(
-        path=package_path, name=pkg_name, fully_qualified_name=pkg_name, modules=[]
+        path=package_path,
+        name=pkg_name,
+        fully_qualified_name=fq_name,
+        parent=parent,
+        modules=[],
+        subpackages=[],
     )
-    for file_path in package_path.rglob("*.py"):
-        module = parse_module(file_path, package)
+    # Process modules in the current package directory.
+    for file in package_path.glob("*.py"):
+        module = parse_module(file, package)
         package.modules.append(module)
+    # Process subpackages.
+    for subdir in package_path.iterdir():
+        if subdir.is_dir() and (subdir / "__init__.py").exists():
+            subpkg = crawl_package(subdir, parent=package)
+            package.subpackages.append(subpkg)
     return package
 
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -454,7 +454,6 @@ class MarkdownRenderer:
             # Render all modules
             for module in package.modules:
                 lines.extend(self.render_module(module, is_one_file=is_one_file))
-                lines.append("")
             output = "\n".join(lines)
             if output_path is None:
                 print(output)
@@ -484,7 +483,6 @@ class MarkdownRenderer:
         lines.append("```python")
         lines.append(f"{const.name}{type_str} = {const.value}")
         lines.append("```")
-        lines.append("")
         return lines
 
     def render_module(
@@ -525,7 +523,9 @@ class MarkdownRenderer:
             lines.append(
                 f"- **[Exports](#{self.anchor(module.fully_qualified_name)}-exports)**"
             )
-        lines.append("")
+
+        if module.constants or module.functions or module.classes or module.exports:
+            lines.append("")
 
         # Detailed sections.
         if module.constants:
@@ -533,6 +533,7 @@ class MarkdownRenderer:
             lines.append("")
             for const in module.constants:
                 lines.extend(self.render_constant(const, level=level + 1))
+            lines.append("")
         if module.functions:
             lines.append(f"{header_prefix}# Functions")
             lines.append("")
@@ -557,7 +558,7 @@ class MarkdownRenderer:
                 link = f"#{self.anchor(fqn)}" if is_one_file else f"{fqn}.md"
                 lines.append(f"- 🅼 [`{exp}`]({link})")
             lines.append("")
-
+        lines.pop()
         return lines
 
     def render_class_toc(self, module: Module, cls: Class, indent: int) -> list[str]:
@@ -587,6 +588,7 @@ class MarkdownRenderer:
         lines.append("")
         if cls.docstring:
             lines.extend(self.render_docstring(cls.docstring))
+            lines.append("")
         if cls.functions:
             lines.append("**Functions:**")
             lines.append("")
@@ -598,6 +600,7 @@ class MarkdownRenderer:
             for nested in cls.classes:
                 lines.extend(self.render_class_details(nested, level=level))
             lines.append("")
+        lines.pop()
         return lines
 
     def render_function(self, func: Function, level: int) -> list[str]:
@@ -616,6 +619,8 @@ class MarkdownRenderer:
         lines.append("")
         if func.docstring:
             lines.extend(self.render_docstring(func.docstring))
+            lines.append("")
+        lines.pop()
         return lines
 
     def render_docstring(
@@ -628,10 +633,10 @@ class MarkdownRenderer:
         indent_str = "  " * indent
         lines: list[str] = []
         if doc.short_description:
-            lines.append(f"{indent_str}{doc.short_description}")
+            lines.append(f"{indent_str}{doc.short_description.strip()}")
             lines.append("")
         if doc.long_description:
-            lines.append(f"{indent_str}{doc.long_description}")
+            lines.append(f"{indent_str}{doc.long_description.strip()}")
             lines.append("")
         if doc.params:
             lines.append(f"{indent_str}**Parameters:**")
@@ -643,7 +648,7 @@ class MarkdownRenderer:
                 if param.default:
                     line += f" (default: `{param.default}`)"
                 if param.description:
-                    line += f": {param.description}"
+                    line += f": {param.description.strip()}"
                 lines.append(line)
             lines.append("")
         if doc.attrs:
@@ -654,7 +659,7 @@ class MarkdownRenderer:
                 if attr.type_name:
                     line += f" (`{attr.type_name}`)"
                 if attr.description:
-                    line += f": {attr.description}"
+                    line += f": {attr.description.strip()}"
                 lines.append(line)
             lines.append("")
         if doc.returns:
@@ -664,7 +669,7 @@ class MarkdownRenderer:
             if doc.returns.type_name:
                 ret_line += f"`{doc.returns.type_name}`: "
             if doc.returns.description:
-                ret_line += f"{doc.returns.description}"
+                ret_line += f"{doc.returns.description.strip()}"
             else:
                 # Trim the trailing colon if no description is provided.
                 ret_line = ret_line[:-2]
@@ -674,10 +679,14 @@ class MarkdownRenderer:
             lines.append(f"{indent_str}**Raises:**")
             lines.append("")
             for raise_item in doc.raises:
-                lines.append(
-                    f"{indent_str}- **{raise_item.type_name}**: {raise_item.description}"
-                )
+                raise_line = f"{indent_str}- **{raise_item.type_name}**: "
+                if raise_item.description:
+                    raise_line += f"{raise_item.description.strip()}"
+                else:
+                    raise_line = raise_line[:-2]
+                lines.append(raise_line)
             lines.append("")
+        lines.pop()
         return lines
 
     def anchor(self, fq_name: str) -> str:

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -662,29 +662,18 @@ class MarkdownRenderer:
         include_toc: bool = False,
     ) -> None:
         """
-        Render a package to a series of files, one for each module.
-
-        If the path is a file rather than a directory, render an index file at that location,
-        then write each module to a separate file. The index file includes just a table of
-        contents that links to all other modules and their classes and functions. If the path
-        is a directory, simply render each module to a file in that directory.
-
-        :param package: The package to render
-        :type package: Package
-        :param path: The path to the output directory or file
-        :type path: Path
-        :param include_toc: Whether to include a table of contents
-        :type include_toc: bool
+        Render a package to a series of files, one for each module. Renders an
+        index file named after the package at the given path that includes a table of
+        contents for all modules, classes, functions, and constants.
         """
-        out_dir = path
-        if path.is_file():
-            out_dir = path.parent
-            toc_lines = self.render_toc(package, file_links=True)
-            with path.open("w", encoding="utf8") as f:
-                f.write("\n".join(toc_lines))
+        assert path.is_dir()
+        path.mkdir(parents=True, exist_ok=True)
+        package_path = path / (package.fully_qualified_name + ".md")
+        toc_lines = self.render_toc(package, file_links=True)
+        with package_path.open("w", encoding="utf8") as f:
+            f.write("\n".join(toc_lines))
         for module in package.modules:
-            filename = module.fully_qualified_name + ".md"
-            module_path = out_dir / filename
+            module_path = path / (module.fully_qualified_name + ".md")
             self.render_file(module, module_path, include_toc=include_toc)
 
 
@@ -701,17 +690,37 @@ def main() -> None:
         action="store_true",
         help="Include private functions, classes, and constants (names starting with '_')",
     )
+    parser.add_argument(
+        "--exclude-toc",
+        dest="exclude_toc",
+        action="store_true",
+        help="Exclude a table of contents from the output",
+    )
+    parser.add_argument(
+        "--path",
+        help="Optional output path. If a file, the output is written to that file. "
+        "If a directory, one file per module is generated. If not provided, output is printed to stdout.",
+    )
     args = parser.parse_args()
-
     package_dir = Path(args.package_path)
+
     if not package_dir.is_dir():
         print(f"Error: {package_dir} is not a directory.")
         return
 
     package = crawl_package(package_dir)
     renderer = MarkdownRenderer(include_private=args.include_private)
-    markdown_output = renderer.render(package, True)
-    print("\n".join(markdown_output))
+    include_toc = not args.exclude_toc
+
+    if args.path:
+        output_path = Path(args.path)
+        if output_path.is_dir():
+            renderer.render_files(package, output_path, include_toc=include_toc)
+        else:
+            renderer.render_file(package, output_path, include_toc=include_toc)
+    else:
+        markdown_output = renderer.render(package, include_toc=include_toc)
+        print("\n".join(markdown_output))
 
 
 if __name__ == "__main__":

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -35,9 +35,7 @@ class DocumentedItem(Protocol):
 class Package:
     path: Path
     name: str  # final name (directory name)
-    fully_qualified_name: str  # e.g. "mypkg" or "parent.child"
-    parent: Package | None = None
-    subpackages: list[Package] = field(default_factory=list)
+    fully_qualified_name: str  # same as name for the top-level package
     modules: list[Module] = field(default_factory=list)
 
 
@@ -68,7 +66,6 @@ class Class:
     # Can be either a module or another class (for nested classes)
     parent: Module | Class
     docstring: docstring_parser.Docstring | None = None
-    constants: list[Constant] = field(default_factory=list)  # New: class-level constants
     functions: list[Function] = field(default_factory=list)
     classes: list[Class] = field(default_factory=list)  # For nested classes
 
@@ -88,7 +85,6 @@ class Constant:
     path: Path
     name: str  # constant name
     fully_qualified_name: str  # e.g. foo.bar.MY_CONSTANT
-    parent: Module | Class
     value: str  # the string representation of the value
     type: str | None = None  # the constant's type, if available
 
@@ -173,7 +169,7 @@ def parse_function(
 
 
 def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> Class:
-    """Parse a class node into a Class dataclass instance and process its methods, constants, and nested classes."""
+    """Parse a class node into a Class dataclass instance and process its methods and nested classes."""
     raw_doc = ast.get_docstring(node)
     parsed_doc = docstring_parser.parse(raw_doc) if raw_doc else None
     fq_name = f"{parent.fully_qualified_name}.{node.name}"
@@ -190,11 +186,10 @@ def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> 
         signature=signature,
         parent=parent,
         docstring=parsed_doc,
-        constants=[],
         functions=[],
         classes=[],
     )
-    # Process methods, nested classes, and class-level constants.
+    # Process methods and nested classes.
     for child in node.body:
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
             method = parse_function(child, file_path, parent=cls)
@@ -202,51 +197,6 @@ def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> 
         elif isinstance(child, ast.ClassDef):
             nested_cls = parse_class(child, parent=cls, file_path=file_path)
             cls.classes.append(nested_cls)
-        elif isinstance(child, (ast.Assign, ast.AnnAssign)):
-            # Process assignments as class constants if they are ALL CAPS and not "__ALL__"
-            if isinstance(child, ast.Assign):
-                for target in child.targets:
-                    if (
-                        isinstance(target, ast.Name)
-                        and target.id.isupper()
-                        and target.id != "__ALL__"
-                    ):
-                        type_annotation = None
-                        if hasattr(child, "type_comment") and child.type_comment:
-                            type_annotation = child.type_comment
-                        value = ast.unparse(child.value)
-                        fq_const = f"{cls.fully_qualified_name}.{target.id}"
-                        constant = Constant(
-                            path=file_path,
-                            name=target.id,
-                            fully_qualified_name=fq_const,
-                            value=value,
-                            type=type_annotation,
-                            parent=cls,
-                        )
-                        cls.constants.append(constant)
-            elif isinstance(child, ast.AnnAssign):
-                if (
-                    isinstance(child.target, ast.Name)
-                    and child.target.id.isupper()
-                    and child.target.id != "__ALL__"
-                ):
-                    type_annotation = (
-                        ast.unparse(child.annotation) if child.annotation else None
-                    )
-                    value = (
-                        ast.unparse(child.value) if child.value is not None else "None"
-                    )
-                    fq_const = f"{cls.fully_qualified_name}.{child.target.id}"
-                    constant = Constant(
-                        path=file_path,
-                        name=child.target.id,
-                        fully_qualified_name=fq_const,
-                        value=value,
-                        type=type_annotation,
-                        parent=cls,
-                    )
-                    cls.constants.append(constant)
     return cls
 
 
@@ -285,6 +235,7 @@ def parse_module_constants(
     """
     for node in module_ast.body:
         if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            # Process ast.Assign nodes (may have multiple targets).
             if isinstance(node, ast.Assign):
                 for target in node.targets:
                     if (
@@ -296,17 +247,17 @@ def parse_module_constants(
                         if hasattr(node, "type_comment") and node.type_comment:
                             type_annotation = node.type_comment
                         value = ast.unparse(node.value)
-                        fq_const = f"{module.fully_qualified_name}.{target.id}"
+                        fq_name = f"{module.fully_qualified_name}.{target.id}"
                         constant = Constant(
                             path=file_path,
                             name=target.id,
-                            fully_qualified_name=fq_const,
+                            fully_qualified_name=fq_name,
                             value=value,
                             type=type_annotation,
-                            parent=module,
                         )
                         module.constants.append(constant)
                         break
+            # Process annotated assignments.
             elif isinstance(node, ast.AnnAssign):
                 if (
                     isinstance(node.target, ast.Name)
@@ -319,14 +270,13 @@ def parse_module_constants(
                     value = (
                         ast.unparse(node.value) if node.value is not None else "None"
                     )
-                    fq_const = f"{module.fully_qualified_name}.{node.target.id}"
+                    fq_name = f"{module.fully_qualified_name}.{node.target.id}"
                     constant = Constant(
                         path=file_path,
                         name=node.target.id,
-                        fully_qualified_name=fq_const,
+                        fully_qualified_name=fq_name,
                         value=value,
                         type=type_annotation,
-                        parent=module,
                     )
                     module.constants.append(constant)
 
@@ -377,7 +327,7 @@ def parse_module(file_path: Path, package: Package) -> Module:
         classes=[],
         exports=[],
     )
-    if file_path.name == "__init__.py":
+    if file_path.name == "__init__":
         module.exports = parse_module_exports(module_ast)
     parse_module_constants(module_ast, module, file_path)
     parse_module_functions(module_ast, module, file_path)
@@ -385,30 +335,15 @@ def parse_module(file_path: Path, package: Package) -> Module:
     return module
 
 
-def crawl_package(package_path: Path, parent: Package | None = None) -> Package:
-    """Recursively crawl the package directory, parsing each .py file as a Module
-    and each subpackage as a Package.
-    A directory is considered a package if it contains an __init__.py file.
-    """
+def crawl_package(package_path: Path) -> Package:
+    """Recursively crawl the package directory, parsing each .py file as a Module."""
     pkg_name = package_path.name
-    fq_name = pkg_name if parent is None else f"{parent.fully_qualified_name}.{pkg_name}"
     package = Package(
-        path=package_path,
-        name=pkg_name,
-        fully_qualified_name=fq_name,
-        parent=parent,
-        modules=[],
-        subpackages=[],
+        path=package_path, name=pkg_name, fully_qualified_name=pkg_name, modules=[]
     )
-    # Process modules in the current package directory.
-    for file in package_path.glob("*.py"):
-        module = parse_module(file, package)
+    for file_path in package_path.rglob("*.py"):
+        module = parse_module(file_path, package)
         package.modules.append(module)
-    # Process subpackages.
-    for subdir in package_path.iterdir():
-        if subdir.is_dir() and (subdir / "__init__.py").exists():
-            subpkg = crawl_package(subdir, parent=package)
-            package.subpackages.append(subpkg)
     return package
 
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -349,15 +349,7 @@ def crawl_package(package_path: Path) -> Package:
 
 # --- Renderer Classes ---
 
-
-class Renderer:
-    def render(self, package: Package) -> str:
-        """Render the Package as a string.
-        This method should be implemented by subclasses."""
-        raise NotImplementedError
-
-
-class MarkdownRenderer(Renderer):
+class MarkdownRenderer:
     def __init__(self, include_private: bool = False):
         # List of tuples: (level, title, slug)
         self.toc: list[tuple[int, str, str]] = []
@@ -574,7 +566,7 @@ class MarkdownRenderer(Renderer):
         lines.extend(children_lines)
         return lines
 
-    def render(self, package: Package) -> str:
+    def render_package(self, package: Package) -> list[str]:
         """
         Render the Package as a Markdown string.
         The table of contents is inserted immediately after the package header.
@@ -594,7 +586,7 @@ class MarkdownRenderer(Renderer):
         final_lines.append("---")
         final_lines.append("")
         final_lines.extend(modules_lines)
-        return "\n".join(final_lines)
+        return final_lines
 
 
 # --- Main function ---
@@ -619,8 +611,8 @@ def main() -> None:
 
     package = crawl_package(package_dir)
     renderer = MarkdownRenderer(include_private=args.include_private)
-    markdown_output = renderer.render(package)
-    print(markdown_output)
+    markdown_output = renderer.render_package(package)
+    print("\n".join(markdown_output))
 
 
 if __name__ == "__main__":

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -518,13 +518,6 @@ class MarkdownRenderer:
                     "  " * 1
                     + f"- [{const.name}](#{self.anchor(module.fully_qualified_name + '.' + const.name)})"
                 )
-        if module.submodules:
-            lines.append("- **Submodules:**")
-            for submod in module.submodules:
-                lines.append(
-                    "  " * 1
-                    + f"- [{submod.fully_qualified_name}](#{self.anchor(submod.fully_qualified_name)})"
-                )
         lines.append("")
 
         # Detailed sections.
@@ -556,12 +549,6 @@ class MarkdownRenderer:
             lines.append("")
             for cls in module.classes:
                 lines.extend(self.render_class_details(cls, level=level + 1))
-            lines.append("")
-        if module.submodules:
-            lines.append("#### Submodules")
-            lines.append("")
-            for submod in module.submodules:
-                lines.extend(self.render_module(submod, level=level + 1))
             lines.append("")
 
         return lines

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -9,6 +9,8 @@ Additional features:
   - For each function/method, its signature is included with type hints (if present) and its return type.
   - Autodetects docstring formats (Google-style, NumPy-style, etc.) and reformats them into Markdown.
   - Constants are detected and their types are included when available.
+  - Classes now include a signature (showing base classes) and are rendered with their signature.
+  - Parameter and return sections now include type information when available.
 """
 
 from __future__ import annotations
@@ -40,10 +42,10 @@ class Package:
 @dataclass
 class Module:
     path: Path
-    name: str  # final module name (file stem)
-    fully_qualified_name: (
-        str  # e.g. package_name.module or just package_name for __init__
-    )
+    # final module name (file stem)
+    name: str
+    # e.g. package_name.module or just package_name for __init__
+    fully_qualified_name: str
     package: Package
     docstring: docstring_parser.Docstring | None = None
     constants: list[Constant] = field(default_factory=list)
@@ -55,11 +57,14 @@ class Module:
 @dataclass
 class Class:
     path: Path
-    name: str  # final class name
-    fully_qualified_name: str  # e.g. foo.bar.Baz
-    parent: (
-        Module | Class
-    )  # Can be either a module or another class (for nested classes)
+    # final class name
+    name: str
+    # e.g. foo.bar.Baz
+    fully_qualified_name: str
+    # the class signature (including base classes)
+    signature: str
+    # Can be either a module or another class (for nested classes)
+    parent: Module | Class
     docstring: docstring_parser.Docstring | None = None
     functions: list[Function] = field(default_factory=list)
     classes: list[Class] = field(default_factory=list)  # For nested classes
@@ -168,10 +173,17 @@ def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> 
     raw_doc = ast.get_docstring(node)
     parsed_doc = docstring_parser.parse(raw_doc) if raw_doc else None
     fq_name = f"{parent.fully_qualified_name}.{node.name}"
+    # Build a signature for the class, including base classes if any.
+    if node.bases:
+        bases = ", ".join(ast.unparse(base) for base in node.bases)
+        signature = f"class {node.name}({bases}):"
+    else:
+        signature = f"class {node.name}:"
     cls = Class(
         path=file_path,
         name=node.name,
         fully_qualified_name=fq_name,
+        signature=signature,
         parent=parent,
         docstring=parsed_doc,
         functions=[],
@@ -211,7 +223,9 @@ def parse_module_exports(module_ast: ast.Module) -> list[str]:
 
 
 def parse_module_constants(
-    module_ast: ast.Module, module: Module, file_path: Path
+    module_ast: ast.Module,
+    module: Module,
+    file_path: Path,
 ) -> None:
     """Parse constants defined in a module.
 
@@ -268,7 +282,9 @@ def parse_module_constants(
 
 
 def parse_module_functions(
-    module_ast: ast.Module, module: Module, file_path: Path
+    module_ast: ast.Module,
+    module: Module,
+    file_path: Path,
 ) -> None:
     """Parse top-level functions in a module."""
     for node in module_ast.body:
@@ -278,7 +294,9 @@ def parse_module_functions(
 
 
 def parse_module_classes(
-    module_ast: ast.Module, module: Module, file_path: Path
+    module_ast: ast.Module,
+    module: Module,
+    file_path: Path,
 ) -> None:
     """Parse classes in a module."""
     for node in module_ast.body:
@@ -309,7 +327,7 @@ def parse_module(file_path: Path, package: Package) -> Module:
         classes=[],
         exports=[],
     )
-    if file_path.name == "__init__.py":
+    if file_path.name == "__init__":
         module.exports = parse_module_exports(module_ast)
     parse_module_constants(module_ast, module, file_path)
     parse_module_functions(module_ast, module, file_path)
@@ -333,30 +351,41 @@ def reformat_docstring(doc: docstring_parser.Docstring | None) -> str:
     """
     Reformat the parsed docstring into Markdown.
     This implementation produces Markdown by concatenating the short and long descriptions,
-    and listing parameters, return info, and exceptions.
+    and listing parameters (with types if available), return info (with type), and exceptions.
     """
     if doc is None:
         return ""
     lines = []
     if doc.short_description:
         lines.append(doc.short_description)
+        lines.append("")
     if doc.long_description:
-        lines.append("")
         lines.append(doc.long_description)
+        lines.append("")
     if doc.params:
-        lines.append("")
         lines.append("**Parameters:**")
+        lines.append("")
         for param in doc.params:
-            lines.append(f"- **{param.arg_name}**: {param.description}")
+            param_line = f"- **{param.arg_name}**"
+            if param.type_name:
+                param_line += f" ({param.type_name})"
+            param_line += f": {param.description}"
+            lines.append(param_line)
+        lines.append("")
     if doc.returns:
-        lines.append("")
         lines.append("**Returns:**")
-        lines.append(f"- {doc.returns.description}")
-    if doc.raises:
         lines.append("")
+        ret_line = "- "
+        if doc.returns.type_name:
+            ret_line += f"({doc.returns.type_name}) "
+        ret_line += f"{doc.returns.description}"
+        lines.append(ret_line)
+        lines.append("")
+    if doc.raises:
         lines.append("**Raises:**")
         for exception in doc.raises:
             lines.append(f"- **{exception.type_name}**: {exception.description}")
+        lines.append("")
     return "\n".join(lines).strip()
 
 
@@ -386,18 +415,19 @@ class MarkdownRenderer(Renderer):
         return text
 
     def render_header(
-        self, level: int, item: DocumentedItem, title_override: str | None = None
+        self,
+        level: int,
+        item: DocumentedItem,
     ) -> list[str]:
         """
         Render a header using a documented data class.
-        Uses the item's fully qualified name (slugified) as the anchor, and the title_override
+        Uses the item's name (slugified) as the anchor, and the title_override
         if provided; otherwise uses the item's name.
         Records the header in the TOC and returns a list of Markdown lines.
         """
-        title = title_override if title_override is not None else item.name
-        slug = self.slugify(item.fully_qualified_name)
-        self.toc.append((level, title, slug))
-        return [f'<a id="{slug}"></a>', f"{'#' * level} {title}"]
+        slug = self.slugify(item.name)
+        self.toc.append((level, item.name, slug))
+        return [f'<a id="{slug}"></a>', f"{'#' * level} {item.name}"]
 
     def render_toc(self) -> list[str]:
         """Render the table of contents based on the collected headers."""
@@ -417,9 +447,15 @@ class MarkdownRenderer(Renderer):
         """Render a constant to Markdown and return the lines as a list of strings."""
         lines = []
         # Render constant header with its fully qualified name.
-        lines.extend(
-            self.render_header(heading_level, const, title_override=f"`{const.name}`")
-        )
+        lines.extend(self.render_header(heading_level, const))
+        lines.append("")
+        lines.append("**Import**")
+        lines.append("")
+        lines.append(f"```python")
+        lines.append(f"import {const.fully_qualified_name}")
+        lines.append("```")
+        lines.append("")
+        lines.append("**Signature**")
         lines.append("")
         lines.append("```python")
         if const.type:
@@ -437,23 +473,40 @@ class MarkdownRenderer(Renderer):
             return []
         lines = []
         # For functions, override the header title to wrap the name in backticks.
-        lines.extend(
-            self.render_header(heading_level, func, title_override=f"`{func.name}`")
-        )
+        lines.extend(self.render_header(heading_level, func))
+        lines.append("")
+        lines.append("**Signature**")
         lines.append("")
         lines.append("```python")
         lines.append(func.signature)
         lines.append("```")
         lines.append("")
         if doc:
-            lines.append("**Docstring:**")
-            lines.append("")
             lines.append(doc)
             lines.append("")
         return lines
 
     def render_class(self, cls: Class, heading_level: int) -> list[str]:
-        """Recursively render a class, its methods, and nested classes."""
+        """Recursively render a class, its signature, its methods, and nested classes.
+
+        Note: The header for the class is rendered before its children, so that it appears
+        correctly in the table of contents.
+        """
+        # Render the class header first.
+        md = []
+        md.extend(self.render_header(heading_level, cls))
+        md.append("")
+        md.append("**Signature**")
+        md.append("")
+        md.append("```python")
+        md.append(cls.signature)
+        md.append("```")
+        md.append("")
+        doc = reformat_docstring(cls.docstring)
+        if doc:
+            md.append(doc)
+            md.append("")
+        # Then render its children.
         child_lines = []
         for method in cls.functions:
             rendered = self.render_function(method, heading_level=heading_level + 1)
@@ -464,22 +517,26 @@ class MarkdownRenderer(Renderer):
             if rendered:
                 child_lines.extend(rendered)
                 child_lines.append("")
-        doc = reformat_docstring(cls.docstring)
-        if self.exclude_empty and not doc and not child_lines:
-            return []
-        md = []
-        md.extend(self.render_header(heading_level, cls))
-        md.append("")
-        if doc:
-            md.append("**Docstring:**")
-            md.append("")
-            md.append(doc)
-            md.append("")
         md.extend(child_lines)
         return md
 
     def render_module(self, module: Module) -> list[str]:
         """Render a module and its children."""
+        # Render the module header first.
+        lines = []
+        lines.extend(self.render_header(2, module))
+        lines.append("")
+
+        module_doc = reformat_docstring(module.docstring)
+        if module_doc:
+            lines.append(module_doc)
+            lines.append("")
+        if module.exports:
+            for export in module.exports:
+                lines.append(f"- `{export}`")
+            lines.append("")
+
+        # Now render the children.
         children_lines = []
         for const in module.constants:
             rendered = self.render_constant(const, heading_level=3)
@@ -494,24 +551,7 @@ class MarkdownRenderer(Renderer):
             if rendered:
                 children_lines.extend(rendered)
                 children_lines.append("")
-        module_doc = reformat_docstring(module.docstring)
-        if (
-            self.exclude_empty
-            and not module_doc
-            and not module.exports
-            and not children_lines
-        ):
-            return []
-        lines = []
-        lines.extend(self.render_header(2, module))
-        lines.append("")
-        if module_doc:
-            lines.append(module_doc)
-            lines.append("")
-        if module.exports:
-            for export in module.exports:
-                lines.append(f"- `{export}`")
-            lines.append("")
+
         lines.extend(children_lines)
         return lines
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -473,7 +473,9 @@ class MarkdownRenderer:
             # Write the index file table of contents linking to each module
             (output_path / "index.md").write_text("\n".join(lines), encoding="utf8")
 
-    def render_module(self, module: Module, level: int = 2, is_one_file: bool = True) -> list[str]:
+    def render_module(
+        self, module: Module, level: int = 2, is_one_file: bool = True
+    ) -> list[str]:
         """
         Render a module section that includes the module's signature (if any), its docstring details,
         and a table of contents linking to its classes, functions, constants, exports, and submodules.
@@ -494,7 +496,9 @@ class MarkdownRenderer:
         lines.append(f"{header_prefix}# Contents")
         lines.append("")
         if module.exports:
-            lines.append(f"- **[Exports](#{self.anchor(module.fully_qualified_name)}-exports)**")
+            lines.append(
+                f"- **[Exports](#{self.anchor(module.fully_qualified_name)}-exports)**"
+            )
         if module.classes:
             lines.append("- **Classes:**")
             for cls in module.classes:
@@ -502,22 +506,18 @@ class MarkdownRenderer:
         if module.functions:
             lines.append("- **Functions:**")
             for func in module.functions:
-                lines.append(
-                    "  " * 1
-                    + f"- [{func.name}]({self.link(module, func)})"
-                )
+                lines.append("  " * 1 + f"- [{func.name}]({self.link(module, func)})")
         if module.constants:
             lines.append("- **Constants:**")
             for const in module.constants:
-                lines.append(
-                    "  " * 1
-                    + f"- [{const.name}]({self.link(module, const)})"
-                )
+                lines.append("  " * 1 + f"- [{const.name}]({self.link(module, const)})")
         lines.append("")
 
         # Detailed sections.
         if module.exports:
-            lines.append(f'<a name="{self.anchor(module.fully_qualified_name)}-exports"></a>')
+            lines.append(
+                f'<a name="{self.anchor(module.fully_qualified_name)}-exports"></a>'
+            )
             lines.append("#### Exports")
             lines.append("")
             for exp in module.exports:
@@ -679,8 +679,12 @@ class MarkdownRenderer:
         """
         return fq_name.replace(".", "-")
 
-
-    def link(self, module: Module, item: DocumentedItem | None = None, is_in_file: bool = True) -> str:
+    def link(
+        self,
+        module: Module,
+        item: DocumentedItem | None = None,
+        is_in_file: bool = True,
+    ) -> str:
         """
         Generate a link to a fully qualified name.
         """

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -368,20 +368,6 @@ def reformat_docstring(doc: docstring_parser.Docstring | None, signature: str | 
         lines.append("```python")
         lines.append(signature)
         lines.append("```")
-    if doc.attrs:
-        lines.append("**Attributes:**")
-        lines.append("")
-        for attr in doc.attrs:
-            attr_line = f"- `{attr.arg_name}`"
-            if attr.type_name:
-                attr_line += f" (**{attr.type_name}**)"
-            attr_line += f": {attr.description}"
-            if attr.default:
-                attr_line += f" (default: `{attr.default}`)"
-            if attr.is_optional:
-                attr_line += " (optional)"
-            lines.append(attr_line)
-        lines.append("")
     if doc.params:
         lines.append("**Parameters:**")
         lines.append("")

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -457,8 +457,18 @@ class MarkdownRenderer:
         slug = self.slugify(item.name)
         return [f'<a id="{slug}"></a>', f"{'#' * level} `{item.fully_qualified_name}`"]
 
-    def render_toc(self, root: Package | Module) -> list[str]:
-        """Render the table of contents based on the collected headers."""
+    def render_toc(self, root: Package | Module, file_links: bool = False) -> list[str]:
+        """
+        Render the table of contents based on the collected headers. If file_links is
+        True, links will be constructed as file references.
+
+        :param root: The root of the package to render
+        :type root: Package | Module
+        :param file_links: Whether to link to files rather than individual items
+        :type file_links: bool
+        :return: A list of lines to render
+        :rtype: list[str]
+        """
         lines = []
 
         def render_item(
@@ -467,12 +477,26 @@ class MarkdownRenderer:
         ) -> None:
             indent = "  " * (level - 1)
             slug = self.slugify(item.name)
-            lines.append(f"{indent}- [`{item.name}`](#{slug})")
+            if file_links:
+                if isinstance(item, Module):
+                    # For a module, link to its file.
+                    filename = item.fully_qualified_name + ".md"
+                    link = f"[`{item.name}`]({filename})"
+                else:
+                    # For other items, find the module that owns them and add an anchor.
+                    parent = item
+                    while not isinstance(parent, Module):
+                        parent = parent.parent  # type: ignore
+                    filename = parent.fully_qualified_name + ".md"
+                    link = f"[`{item.name}`]({filename}#{slug})"
+            else:
+                link = f"[`{item.name}`](#{slug})"
+            lines.append(f"{indent}- {link}")
             match item:
-                case Package(_):
+                case Package():
                     for module in item.modules:
                         render_item(level + 1, module)
-                case Module(_):
+                case Module():
                     for constant in item.constants:
                         if self.is_private(constant):
                             continue
@@ -485,7 +509,7 @@ class MarkdownRenderer:
                         if self.is_private(func):
                             continue
                         render_item(level + 1, func)
-                case Class(_):
+                case Class():
                     for cls in item.classes:
                         if self.is_private(cls):
                             continue
@@ -630,6 +654,38 @@ class MarkdownRenderer:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", encoding="utf8") as f:
             f.write("\n".join(self.render(root, include_toc)))
+
+    def render_files(
+        self,
+        package: Package,
+        path: Path,
+        include_toc: bool = False,
+    ) -> None:
+        """
+        Render a package to a series of files, one for each module.
+
+        If the path is a file rather than a directory, render an index file at that location,
+        then write each module to a separate file. The index file includes just a table of
+        contents that links to all other modules and their classes and functions. If the path
+        is a directory, simply render each module to a file in that directory.
+
+        :param package: The package to render
+        :type package: Package
+        :param path: The path to the output directory or file
+        :type path: Path
+        :param include_toc: Whether to include a table of contents
+        :type include_toc: bool
+        """
+        out_dir = path
+        if path.is_file():
+            out_dir = path.parent
+            toc_lines = self.render_toc(package, file_links=True)
+            with path.open("w", encoding="utf8") as f:
+                f.write("\n".join(toc_lines))
+        for module in package.modules:
+            filename = module.fully_qualified_name + ".md"
+            module_path = out_dir / filename
+            self.render_file(module, module_path, include_toc=include_toc)
 
 
 # --- Main function ---

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -9,7 +9,6 @@ Additional features:
   - For each function/method, its signature is included with type hints (if present) and its return type.
   - Autodetects docstring formats (Google-style, NumPy-style, etc.) and reformats them into Markdown.
   - Constants are detected and their types are included when available.
-  - Classes now include a signature (showing base classes) and are rendered with their signature.
   - Parameter and return sections now include type information when available.
 """
 
@@ -17,7 +16,6 @@ from __future__ import annotations
 
 import argparse
 import ast
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
@@ -46,7 +44,7 @@ class Module:
     name: str
     # e.g. package_name.module or just package_name for __init__
     fully_qualified_name: str
-    package: Package
+    submodules: list[Module] = field(default_factory=list)
     docstring: docstring_parser.Docstring | None = None
     constants: list[Constant] = field(default_factory=list)
     functions: list[Function] = field(default_factory=list)
@@ -61,10 +59,7 @@ class Class:
     name: str
     # e.g. foo.bar.Baz
     fully_qualified_name: str
-    # the class signature (including base classes)
     signature: str
-    # Can be either a module or another class (for nested classes)
-    parent: Module | Class
     docstring: docstring_parser.Docstring | None = None
     functions: list[Function] = field(default_factory=list)
     classes: list[Class] = field(default_factory=list)  # For nested classes
@@ -76,7 +71,6 @@ class Function:
     name: str  # final function/method name
     fully_qualified_name: str  # e.g. foo.bar.Baz.method
     signature: str
-    parent: Class | Module
     docstring: docstring_parser.Docstring | None = None
 
 
@@ -90,6 +84,19 @@ class Constant:
 
 
 # --- Helper functions ---
+
+
+def should_include(name: str, include_private: bool) -> bool:
+    """
+    Returns True if the given name should be included based on the value
+    of include_private. Always include dunder names like __init__.
+    """
+    if include_private:
+        return True
+    # Exclude names starting with a single underscore.
+    if name.startswith("_") and not (name.startswith("__") and name.endswith("__")):
+        return False
+    return True
 
 
 def get_string_value(node: ast.AST) -> str | None:
@@ -163,12 +170,13 @@ def parse_function(
         name=node.name,
         fully_qualified_name=fq_name,
         signature=signature,
-        parent=parent,
         docstring=parsed_doc,
     )
 
 
-def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> Class:
+def parse_class(
+    node: ast.ClassDef, parent: Module | Class, file_path: Path, include_private: bool
+) -> Class:
     """Parse a class node into a Class dataclass instance and process its methods and nested classes."""
     raw_doc = ast.get_docstring(node)
     parsed_doc = docstring_parser.parse(raw_doc) if raw_doc else None
@@ -184,7 +192,6 @@ def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> 
         name=node.name,
         fully_qualified_name=fq_name,
         signature=signature,
-        parent=parent,
         docstring=parsed_doc,
         functions=[],
         classes=[],
@@ -192,10 +199,16 @@ def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> 
     # Process methods and nested classes.
     for child in node.body:
         if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not should_include(child.name, include_private):
+                continue
             method = parse_function(child, file_path, parent=cls)
             cls.functions.append(method)
         elif isinstance(child, ast.ClassDef):
-            nested_cls = parse_class(child, parent=cls, file_path=file_path)
+            if not should_include(child.name, include_private):
+                continue
+            nested_cls = parse_class(
+                child, parent=cls, file_path=file_path, include_private=include_private
+            )
             cls.classes.append(nested_cls)
     return cls
 
@@ -226,6 +239,7 @@ def parse_module_constants(
     module_ast: ast.Module,
     module: Module,
     file_path: Path,
+    include_private: bool,
 ) -> None:
     """Parse constants defined in a module.
 
@@ -242,6 +256,7 @@ def parse_module_constants(
                         isinstance(target, ast.Name)
                         and target.id.isupper()
                         and target.id != "__ALL__"
+                        and should_include(target.id, include_private)
                     ):
                         type_annotation = None
                         if hasattr(node, "type_comment") and node.type_comment:
@@ -263,6 +278,7 @@ def parse_module_constants(
                     isinstance(node.target, ast.Name)
                     and node.target.id.isupper()
                     and node.target.id != "__ALL__"
+                    and should_include(node.target.id, include_private)
                 ):
                     type_annotation = (
                         ast.unparse(node.annotation) if node.annotation else None
@@ -285,10 +301,13 @@ def parse_module_functions(
     module_ast: ast.Module,
     module: Module,
     file_path: Path,
+    include_private: bool,
 ) -> None:
     """Parse top-level functions in a module."""
     for node in module_ast.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not should_include(node.name, include_private):
+                continue
             func = parse_function(node, file_path, parent=module)
             module.functions.append(func)
 
@@ -297,53 +316,111 @@ def parse_module_classes(
     module_ast: ast.Module,
     module: Module,
     file_path: Path,
+    include_private: bool,
 ) -> None:
     """Parse classes in a module."""
     for node in module_ast.body:
         if isinstance(node, ast.ClassDef):
-            cls = parse_class(node, parent=module, file_path=file_path)
+            if not should_include(node.name, include_private):
+                continue
+            cls = parse_class(
+                node,
+                parent=module,
+                file_path=file_path,
+                include_private=include_private,
+            )
             module.classes.append(cls)
 
 
-def parse_module(file_path: Path, package: Package) -> Module:
+def parse_module_submodules(
+    module: Module,
+    file_path: Path,
+    include_private: bool,
+) -> None:
+    """Parse submodules of a module."""
+    for file_path in file_path.parent.iterdir():
+        init_py = file_path / "__init__.py"
+        if init_py.is_file():
+            submodule = parse_module(
+                init_py,
+                f"{module.fully_qualified_name}.{file_path.name}",
+                include_private,
+            )
+            module.submodules.append(submodule)
+        elif file_path.suffix == ".py" and file_path.stem != "__init__":
+            if (
+                not include_private
+                and file_path.name.startswith("_")
+                and not file_path.name.startswith("__")
+            ):
+                continue
+            submodule = parse_module(
+                file_path,
+                f"{module.fully_qualified_name}",
+                include_private,
+            )
+            module.submodules.append(submodule)
+
+
+def parse_module(
+    file_path: Path,
+    fully_qualified_name: str,
+    include_private: bool,
+) -> Module:
     """Parse a single module file into a Module dataclass instance."""
     with file_path.open("r", encoding="utf8") as f:
         source = f.read()
     module_ast = ast.parse(source, filename=str(file_path))
-    # If the file is __init__.py, use the package's fully qualified name.
     mod_name = file_path.stem
-    if mod_name == "__init__":
-        fq_name = package.fully_qualified_name
-    else:
-        fq_name = f"{package.fully_qualified_name}.{mod_name}"
+    if mod_name != "__init__":
+        fully_qualified_name = f"{fully_qualified_name}.{mod_name}"
     module = Module(
         path=file_path,
         name=mod_name,
-        fully_qualified_name=fq_name,
-        package=package,
+        fully_qualified_name=fully_qualified_name,
         docstring=parse_module_docstring(module_ast),
         constants=[],
         functions=[],
         classes=[],
         exports=[],
     )
-    if file_path.name == "__init__":
+    parse_module_constants(module_ast, module, file_path, include_private)
+    parse_module_functions(module_ast, module, file_path, include_private)
+    parse_module_classes(module_ast, module, file_path, include_private)
+    if mod_name == "__init__":
         module.exports = parse_module_exports(module_ast)
-    parse_module_constants(module_ast, module, file_path)
-    parse_module_functions(module_ast, module, file_path)
-    parse_module_classes(module_ast, module, file_path)
+        parse_module_submodules(module, file_path, include_private)
     return module
 
 
-def crawl_package(package_path: Path) -> Package:
-    """Recursively crawl the package directory, parsing each .py file as a Module."""
+def crawl_package(package_path: Path, include_private: bool = False) -> Package:
+    """Recursively crawl the package directory, parsing each .py file as a Module.
+
+    If include_private is False, items (functions, classes, constants, submodules)
+    whose names start with a single underscore (but not dunder names like __init__)
+    are excluded.
+    """
     pkg_name = package_path.name
     package = Package(
         path=package_path, name=pkg_name, fully_qualified_name=pkg_name, modules=[]
     )
-    for file_path in package_path.rglob("*.py"):
-        module = parse_module(file_path, package)
+    modules = []
+    for file_path in package_path.glob("*.py"):
+        if (
+            not include_private
+            and file_path.stem.startswith("_")
+            and not file_path.stem.startswith("__")
+        ):
+            continue
+        module = parse_module(file_path, package.fully_qualified_name, include_private)
+        modules.append(module)
+
+    # Add all modules to the package (including nested)
+    while modules:
+        module = modules.pop()
         package.modules.append(module)
+        modules.extend(module.submodules)
+
     return package
 
 
@@ -351,330 +428,270 @@ def crawl_package(package_path: Path) -> Package:
 
 
 class MarkdownRenderer:
-    def __init__(self, include_private: bool = False):
-        self.include_private = include_private
-
-    @staticmethod
-    def slugify(text: str) -> str:
-        """Convert text to a slug suitable for use as an anchor."""
-        text = text.lower()
-        text = text.replace(".", "-")  # Replace dots with dashes.
-        text = re.sub(r"[^a-z0-9\s-]", "", text)
-        text = re.sub(r"\s+", "-", text).strip("-")
-        return text
-
-    def is_private(self, item: DocumentedItem) -> bool:
-        """Return True if the item is considered private."""
-        return not self.include_private and (
-            item.name.startswith("_")
-            and not (item.name.startswith("__") and item.name.endswith("__"))
+    def render(self, package: Package, output_path: Path | None = None) -> None:
+        """
+        Render the given package as Markdown. If output_path is None or '-', output to stdout.
+        If output_path is a directory, each module gets its own file; otherwise, all modules go into one file.
+        """
+        is_one_file = (
+            output_path is None or output_path.is_file() or output_path.suffix != ""
         )
-
-    def render_docstring(
-        self,
-        doc: docstring_parser.Docstring | None,
-        signature: str | None = None,
-    ) -> str:
-        """
-        Reformat the parsed docstring into Markdown.
-        This implementation produces Markdown by concatenating the short and long descriptions,
-        and listing parameters (with types if available), return info (with type), and exceptions.
-        """
-        if doc is None:
-            return ""
         lines = []
-        if doc.short_description:
-            lines.append(doc.short_description)
-            lines.append("")
-        if doc.long_description:
-            lines.append(doc.long_description)
-            lines.append("")
-        if signature:
-            lines.append("**Signature:**")
-            lines.append("")
-            lines.append("```python")
-            lines.append(signature)
-            lines.append("```")
-        if doc.attrs:
-            lines.append("**Attributes:**")
-            lines.append("")
-            for attr in doc.attrs:
-                attr_line = f"- `{attr.arg_name}`"
-                if attr.type_name:
-                    attr_line += f" (**{attr.type_name}**)"
-                attr_line += f": {attr.description}"
-                if attr.default:
-                    attr_line += f" (default: `{attr.default}`)"
-                if attr.is_optional:
-                    attr_line += " (optional)"
-                lines.append(attr_line)
-            lines.append("")
-        if doc.params:
-            lines.append("**Parameters:**")
-            lines.append("")
-            for param in doc.params:
-                param_line = f"- `{param.arg_name}`"
-                if param.type_name:
-                    param_line += f" (**{param.type_name}**)"
-                param_line += f": {param.description}"
-                if param.default:
-                    param_line += f" (default: `{param.default}`)"
-                if param.is_optional:
-                    param_line += " (optional)"
-                lines.append(param_line)
-            lines.append("")
-        if doc.examples:
-            lines.append("**Examples:**")
-            lines.append("")
-            for example in doc.examples:
-                if example.snippet:
-                    lines.append("```python")
-                    lines.append(example.snippet)
-                    lines.append("```")
-                    lines.append("")
-        if doc.returns:
-            lines.append("**Returns:**")
-            lines.append("")
-            ret_line = "- "
-            if doc.returns.type_name:
-                ret_line += f"(**{doc.returns.type_name}**) "
-            ret_line += f"{doc.returns.description}"
-            lines.append(ret_line)
-            lines.append("")
-        if doc.raises:
-            lines.append("**Raises:**")
-            for exception in doc.raises:
-                lines.append(f"- (**{exception.type_name}**) {exception.description}")
-            lines.append("")
-        return "\n".join(lines).strip()
-
-    def render_header(
-        self,
-        level: int,
-        item: DocumentedItem,
-    ) -> list[str]:
-        """Render a header using a documented data class."""
-        slug = self.slugify(item.name)
-        return [f'<a id="{slug}"></a>', f"{'#' * level} `{item.fully_qualified_name}`"]
-
-    def render_toc(self, root: Package | Module, file_links: bool = False) -> list[str]:
-        """
-        Render the table of contents based on the collected headers. If file_links is
-        True, links will be constructed as file references.
-
-        :param root: The root of the package to render
-        :type root: Package | Module
-        :param file_links: Whether to link to files rather than individual items
-        :type file_links: bool
-        :return: A list of lines to render
-        :rtype: list[str]
-        """
-        lines = []
-
-        def render_item(
-            level: int,
-            item: Package | Module | Class | Function | Constant,
-        ) -> None:
-            indent = "  " * (level - 1)
-            slug = self.slugify(item.name)
-            if file_links:
-                if isinstance(item, Module):
-                    # For a module, link to its file.
-                    filename = item.fully_qualified_name + ".md"
-                    link = f"[`{item.name}`]({filename})"
-                else:
-                    # For other items, find the module that owns them and add an anchor.
-                    parent = item
-                    while not isinstance(parent, Module):
-                        parent = parent.parent  # type: ignore
-                    filename = parent.fully_qualified_name + ".md"
-                    link = f"[`{item.name}`]({filename}#{slug})"
-            else:
-                link = f"[`{item.name}`](#{slug})"
-            lines.append(f"{indent}- {link}")
-            match item:
-                case Package():
-                    for module in item.modules:
-                        render_item(level + 1, module)
-                case Module():
-                    for constant in item.constants:
-                        if self.is_private(constant):
-                            continue
-                        render_item(level + 1, constant)
-                    for cls in item.classes:
-                        if self.is_private(cls):
-                            continue
-                        render_item(level + 1, cls)
-                    for func in item.functions:
-                        if self.is_private(func):
-                            continue
-                        render_item(level + 1, func)
-                case Class():
-                    for cls in item.classes:
-                        if self.is_private(cls):
-                            continue
-                        render_item(level + 1, cls)
-                    for func in item.functions:
-                        if self.is_private(func):
-                            continue
-                        render_item(level + 1, func)
-                case _:
-                    pass
-
-        render_item(1, root)
+        lines.append(f"# `{package.name}`")
         lines.append("")
+        lines.append("## Table of Contents")
+        lines.append("")
+        for module in package.modules:
+            link = (
+                f"#{self.anchor(module.fully_qualified_name)}"
+                if is_one_file
+                else f"{module.fully_qualified_name}.md"
+            )
+            lines.append(f"- [{module.fully_qualified_name}]({link})")
+        lines.append("")
+
+        if is_one_file:
+            # Render all modules
+            for module in package.modules:
+                lines.extend(self.render_module(module))
+                lines.append("")
+            output = "\n".join(lines)
+            if output_path is None:
+                print(output)
+            else:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(output, encoding="utf8")
+        elif output_path is not None:
+            # If the output path has no suffix, treat it as a directory.
+            output_path.mkdir(parents=True, exist_ok=True)
+            for module in package.modules:
+                module_lines = self.render_module(module)
+                module_output = "\n".join(module_lines)
+                # File name derived from fully qualified name (dots replaced with underscores)
+                file_name = f"{module.fully_qualified_name}.md"
+                file_path = output_path / file_name
+                file_path.write_text(module_output, encoding="utf8")
+            (output_path / "index.md").write_text("\n".join(lines), encoding="utf8")
+
+    def render_module(self, module: Module, level: int = 2) -> list[str]:
+        """
+        Render a module section that includes the module's signature (if any), its docstring details,
+        and a table of contents linking to its classes, functions, constants, exports, and submodules.
+        """
+        lines: list[str] = []
+        header_prefix = "#" * level
+        # Module header with an HTML anchor.
+        lines.append(
+            f'{header_prefix} {module.fully_qualified_name} <a name="{self.anchor(module.fully_qualified_name)}"></a>'
+        )
+        lines.append("")
+
+        # Render module docstring details if available.
+        if module.docstring:
+            lines.extend(self.render_docstring(module.docstring))
+
+        # Second-level table of contents for this module.
+        lines.append(f"{header_prefix}# Contents")
+        lines.append("")
+        if module.exports:
+            # Create links for each export; assume exports are names defined in __init__.
+            export_links = ", ".join(
+                f"[{exp}](#{self.anchor(module.fully_qualified_name + '.' + exp)})"
+                for exp in module.exports
+            )
+            lines.append(f"- **Exports:** {export_links}")
+        if module.classes:
+            lines.append("- **Classes:**")
+            for cls in module.classes:
+                lines.extend(self.render_class_toc(cls, indent=1))
+        if module.functions:
+            lines.append("- **Functions:**")
+            for func in module.functions:
+                lines.append(
+                    "  " * 1
+                    + f"- [{func.name}](#{self.anchor(func.fully_qualified_name)})"
+                )
+        if module.constants:
+            lines.append("- **Constants:**")
+            for const in module.constants:
+                lines.append(
+                    "  " * 1
+                    + f"- [{const.name}](#{self.anchor(module.fully_qualified_name + '.' + const.name)})"
+                )
+        if module.submodules:
+            lines.append("- **Submodules:**")
+            for submod in module.submodules:
+                lines.append(
+                    "  " * 1
+                    + f"- [{submod.fully_qualified_name}](#{self.anchor(submod.fully_qualified_name)})"
+                )
+        lines.append("")
+
+        # Detailed sections.
+        if module.exports:
+            lines.append("#### Exports")
+            lines.append("")
+            for exp in module.exports:
+                lines.append(f"- `{exp}`")
+            lines.append("")
+        if module.constants:
+            lines.append("#### Constants")
+            lines.append("")
+            for const in module.constants:
+                type_str = f": {const.type}" if const.type else ""
+                lines.append(f"- **{const.name}**{type_str}")
+                lines.append("")
+                lines.append("```python")
+                lines.append(f"{const.name} = {const.value}")
+                lines.append("```")
+                lines.append("")
+        if module.functions:
+            lines.append("#### Functions")
+            lines.append("")
+            for func in module.functions:
+                lines.extend(self.render_function(func, level=level + 1))
+            lines.append("")
+        if module.classes:
+            lines.append("#### Classes")
+            lines.append("")
+            for cls in module.classes:
+                lines.extend(self.render_class_details(cls, level=level + 1))
+            lines.append("")
+        if module.submodules:
+            lines.append("#### Submodules")
+            lines.append("")
+            for submod in module.submodules:
+                lines.extend(self.render_module(submod, level=level + 1))
+            lines.append("")
+
         return lines
 
-    def render_constant(self, const: Constant, heading_level: int) -> list[str]:
-        """Render a constant to Markdown and return the lines as a list of strings."""
-        # Skip if private.
-        if self.is_private(const):
-            return []
-        lines = []
-        lines.extend(self.render_header(heading_level, const))
+    def render_class_toc(self, cls: Class, indent: int) -> list[str]:
+        """Render a TOC entry for a class and its nested classes."""
+        lines: list[str] = []
+        indent_str = "  " * indent
+        lines.append(
+            f"{indent_str}- [{cls.name}](#{self.anchor(cls.fully_qualified_name)})"
+        )
+        for nested in cls.classes:
+            lines.extend(self.render_class_toc(nested, indent + 1))
+        return lines
+
+    def render_class_details(self, cls: Class, level: int) -> list[str]:
+        """
+        Render detailed documentation for a class including its signature, docstring details,
+        its methods, and any nested classes.
+        """
+        lines: list[str] = []
+        header_prefix = "#" * level
+        lines.append(
+            f'{header_prefix} {cls.fully_qualified_name} <a name="{self.anchor(cls.fully_qualified_name)}"></a>'
+        )
         lines.append("")
         lines.append("```python")
-        if const.type:
-            lines.append(f"{const.name}: {const.type} = {const.value}")
-        else:
-            lines.append(f"{const.name} = {const.value}")
+        lines.append(cls.signature)
         lines.append("```")
         lines.append("")
+        if cls.docstring:
+            lines.extend(self.render_docstring(cls.docstring))
+        if cls.functions:
+            lines.append("**Methods:**")
+            lines.append("")
+            for func in cls.functions:
+                lines.extend(self.render_function(func, level=level + 1))
+            lines.append("")
+        if cls.classes:
+            lines.append("**Nested Classes:**")
+            lines.append("")
+            for nested in cls.classes:
+                lines.extend(self.render_class_details(nested, level=level + 1))
+            lines.append("")
         return lines
 
-    def render_function(self, func: Function, heading_level: int) -> list[str]:
-        """Render a function or method to Markdown and return the lines as a list of strings."""
-        if self.is_private(func):
-            return []
-        doc = self.render_docstring(func.docstring, func.signature)
-        lines = []
-        lines.extend(self.render_header(heading_level, func))
+    def render_function(self, func: Function, level: int) -> list[str]:
+        """
+        Render detailed documentation for a function/method including its signature and
+        docstring details (parameters, returns, raises, etc.).
+        """
+        lines: list[str] = []
+        header_prefix = "#" * level
+        lines.append(
+            f'{header_prefix} {func.fully_qualified_name} <a name="{self.anchor(func.fully_qualified_name)}"></a>'
+        )
         lines.append("")
-        if doc:
-            lines.append(doc)
-            lines.append("")
-        return lines
-
-    def render_class(self, cls: Class, heading_level: int) -> list[str]:
-        """Recursively render a class, its signature, its methods, and nested classes."""
-        if self.is_private(cls):
-            return []
-        md = []
-        md.extend(self.render_header(heading_level, cls))
-        md.append("")
-        doc = self.render_docstring(cls.docstring, cls.signature)
-        if doc:
-            md.append(doc)
-            md.append("")
-        child_lines = []
-        for method in cls.functions:
-            if self.is_private(method):
-                continue
-            rendered = self.render_function(method, heading_level=heading_level + 1)
-            if rendered:
-                child_lines.extend(rendered)
-        for nested in cls.classes:
-            rendered = self.render_class(nested, heading_level=heading_level + 1)
-            if rendered:
-                child_lines.extend(rendered)
-                child_lines.append("")
-        md.extend(child_lines)
-        return md
-
-    def render_module(self, module: Module, include_toc: bool = False) -> list[str]:
-        """Render a module and its children."""
-        lines = []
-        lines.extend(self.render_header(2, module))
+        lines.append("```python")
+        lines.append(func.signature)
+        lines.append("```")
         lines.append("")
-
-        if include_toc:
-            lines.extend(self.render_toc(module))
-            lines.append("")
-
-        module_doc = self.render_docstring(module.docstring)
-        if module_doc:
-            lines.append(module_doc)
-            lines.append("")
-        if module.exports:
-            for export in module.exports:
-                lines.append(f"- `{export}`")
-            lines.append("")
-
-        children_lines = []
-        for const in module.constants:
-            rendered = self.render_constant(const, heading_level=3)
-            if rendered:
-                children_lines.extend(rendered)
-        for func in module.functions:
-            rendered = self.render_function(func, heading_level=3)
-            if rendered:
-                children_lines.extend(rendered)
-        for cls in module.classes:
-            rendered = self.render_class(cls, heading_level=3)
-            if rendered:
-                children_lines.extend(rendered)
-                children_lines.append("")
-        lines.extend(children_lines)
+        if func.docstring:
+            lines.extend(self.render_docstring(func.docstring))
         return lines
 
-    def render_package(self, package: Package, include_toc: bool = False) -> list[str]:
+    def render_docstring(
+        self, doc: docstring_parser.Docstring, indent: int = 0
+    ) -> list[str]:
         """
-        Render the Package as a Markdown string.
-        The table of contents is inserted immediately after the package header.
+        Render detailed docstring information including description, parameters,
+        returns, raises, and attributes. An indent level can be provided for nested output.
         """
-        lines = []
-        lines.extend(self.render_header(1, package))
-        lines.append("")
-        if include_toc:
-            lines.extend(self.render_toc(package))
+        indent_str = "  " * indent
+        lines: list[str] = []
+        if doc.short_description:
+            lines.append(f"{indent_str}{doc.short_description}")
             lines.append("")
-        for module in package.modules:
-            rendered_module = self.render_module(module)
-            if rendered_module:
-                lines.extend(rendered_module)
+        if doc.long_description:
+            lines.append(f"{indent_str}{doc.long_description}")
+            lines.append("")
+        if doc.params:
+            lines.append(f"{indent_str}**Parameters:**")
+            lines.append("")
+            for param in doc.params:
+                line = f"{indent_str}- **{param.arg_name}**"
+                if param.type_name:
+                    line += f" (`{param.type_name}`)"
+                if param.default:
+                    line += f" (default: `{param.default}`)"
+                if param.description:
+                    line += f": {param.description}"
+                lines.append(line)
+            lines.append("")
+        if doc.returns:
+            lines.append(f"{indent_str}**Returns:**")
+            lines.append("")
+            ret_line = ""
+            if doc.returns.type_name:
+                ret_line += f"`{doc.returns.type_name}`"
+            if doc.returns.description:
+                ret_line += f": {doc.returns.description}"
+            lines.append(f"{indent_str}- {ret_line}")
+            lines.append("")
+        if doc.raises:
+            lines.append(f"{indent_str}**Raises:**")
+            lines.append("")
+            for raise_item in doc.raises:
+                lines.append(
+                    f"{indent_str}- **{raise_item.type_name}**: {raise_item.description}"
+                )
+            lines.append("")
+        if doc.attrs:
+            lines.append(f"{indent_str}**Attributes:**")
+            lines.append("")
+            for attr in doc.attrs:
+                line = f"{indent_str}- **{attr.arg_name}**"
+                if attr.type_name:
+                    line += f" (`{attr.type_name}`)"
+                if attr.description:
+                    line += f": {attr.description}"
+                lines.append(line)
+            lines.append("")
         return lines
 
-    def render(self, root: Package | Module, include_toc: bool = False) -> list[str]:
-        """Render the root object as Markdown and return the lines as a list of strings."""
-        match root:
-            case Package():
-                return self.render_package(root, include_toc)
-            case Module():
-                return self.render_module(root, include_toc)
-            case _:
-                raise ValueError(f"Unsupported root type: {type(root)}")
-
-    def render_file(
-        self,
-        root: Package | Module,
-        path: Path,
-        include_toc: bool = False,
-    ) -> None:
-        """Render the root object as Markdown and write it to a file."""
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w", encoding="utf8") as f:
-            f.write("\n".join(self.render(root, include_toc)))
-
-    def render_files(
-        self,
-        package: Package,
-        path: Path,
-        include_toc: bool = False,
-    ) -> None:
+    def anchor(self, fq_name: str) -> str:
         """
-        Render a package to a series of files, one for each module. Renders an
-        index file named after the package at the given path that includes a table of
-        contents for all modules, classes, functions, and constants.
+        Generate a sanitized anchor from a fully qualified name.
+        This implementation replaces dots with hyphens.
         """
-        assert path.is_dir()
-        path.mkdir(parents=True, exist_ok=True)
-        package_path = path / (package.fully_qualified_name + ".md")
-        toc_lines = self.render_toc(package, file_links=True)
-        with package_path.open("w", encoding="utf8") as f:
-            f.write("\n".join(toc_lines))
-        for module in package.modules:
-            module_path = path / (module.fully_qualified_name + ".md")
-            self.render_file(module, module_path, include_toc=include_toc)
+        return fq_name.replace(".", "-")
 
 
 # --- Main function ---
@@ -682,24 +699,18 @@ class MarkdownRenderer:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Crawl a Python package and extract docstrings."
+        description="Crawl a Python package and extract docstrings into Markdown."
     )
     parser.add_argument("package_path", help="Path to the Python package directory")
+    parser.add_argument(
+        "output_path",
+        help="Path to write the Markdown file(s)"
+        "Can be a directory or a single file. If a directory, each module will get its own file.",
+    )
     parser.add_argument(
         "--include-private",
         action="store_true",
         help="Include private functions, classes, and constants (names starting with '_')",
-    )
-    parser.add_argument(
-        "--exclude-toc",
-        dest="exclude_toc",
-        action="store_true",
-        help="Exclude a table of contents from the output",
-    )
-    parser.add_argument(
-        "--path",
-        help="Optional output path. If a file, the output is written to that file. "
-        "If a directory, one file per module is generated. If not provided, output is printed to stdout.",
     )
     args = parser.parse_args()
     package_dir = Path(args.package_path)
@@ -708,19 +719,11 @@ def main() -> None:
         print(f"Error: {package_dir} is not a directory.")
         return
 
-    package = crawl_package(package_dir)
-    renderer = MarkdownRenderer(include_private=args.include_private)
-    include_toc = not args.exclude_toc
+    package = crawl_package(package_dir, include_private=args.include_private)
+    renderer = MarkdownRenderer()
 
-    if args.path:
-        output_path = Path(args.path)
-        if output_path.is_dir():
-            renderer.render_files(package, output_path, include_toc=include_toc)
-        else:
-            renderer.render_file(package, output_path, include_toc=include_toc)
-    else:
-        markdown_output = renderer.render(package, include_toc=include_toc)
-        print("\n".join(markdown_output))
+    output_path = Path(args.output_path)
+    renderer.render(package, output_path)
 
 
 if __name__ == "__main__":

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -442,18 +442,14 @@ class MarkdownRenderer:
         lines.append("## Table of Contents")
         lines.append("")
         for module in package.modules:
-            link = (
-                f"#{self.anchor(module.fully_qualified_name)}"
-                if is_one_file
-                else f"{module.fully_qualified_name}.md"
-            )
+            link = self.link(module, is_in_file=is_one_file)
             lines.append(f"- [{module.fully_qualified_name}]({link})")
         lines.append("")
 
         if is_one_file:
             # Render all modules
             for module in package.modules:
-                lines.extend(self.render_module(module))
+                lines.extend(self.render_module(module, is_one_file=is_one_file))
                 lines.append("")
             output = "\n".join(lines)
             if output_path is None:
@@ -465,15 +461,15 @@ class MarkdownRenderer:
             # If the output path has no suffix, treat it as a directory.
             output_path.mkdir(parents=True, exist_ok=True)
             for module in package.modules:
-                module_lines = self.render_module(module)
+                file_name = self.link(module, is_in_file=is_one_file)
+                module_lines = self.render_module(module, is_one_file=is_one_file)
                 module_output = "\n".join(module_lines)
-                # File name derived from fully qualified name (dots replaced with underscores)
-                file_name = f"{module.fully_qualified_name}.md"
                 file_path = output_path / file_name
                 file_path.write_text(module_output, encoding="utf8")
+            # Write the index file table of contents linking to each module
             (output_path / "index.md").write_text("\n".join(lines), encoding="utf8")
 
-    def render_module(self, module: Module, level: int = 2) -> list[str]:
+    def render_module(self, module: Module, level: int = 2, is_one_file: bool = True) -> list[str]:
         """
         Render a module section that includes the module's signature (if any), its docstring details,
         and a table of contents linking to its classes, functions, constants, exports, and submodules.
@@ -494,38 +490,37 @@ class MarkdownRenderer:
         lines.append(f"{header_prefix}# Contents")
         lines.append("")
         if module.exports:
-            # Create links for each export; assume exports are names defined in __init__.
-            export_links = ", ".join(
-                f"[{exp}](#{self.anchor(module.fully_qualified_name + '.' + exp)})"
-                for exp in module.exports
-            )
-            lines.append(f"- **Exports:** {export_links}")
+            lines.append(f"- **[Exports](#{self.anchor(module.fully_qualified_name)}-exports)**")
         if module.classes:
             lines.append("- **Classes:**")
             for cls in module.classes:
-                lines.extend(self.render_class_toc(cls, indent=1))
+                lines.extend(self.render_class_toc(module, cls, indent=1))
         if module.functions:
             lines.append("- **Functions:**")
             for func in module.functions:
                 lines.append(
                     "  " * 1
-                    + f"- [{func.name}](#{self.anchor(func.fully_qualified_name)})"
+                    + f"- [{func.name}]({self.link(module, func)})"
                 )
         if module.constants:
             lines.append("- **Constants:**")
             for const in module.constants:
                 lines.append(
                     "  " * 1
-                    + f"- [{const.name}](#{self.anchor(module.fully_qualified_name + '.' + const.name)})"
+                    + f"- [{const.name}]({self.link(module, const)})"
                 )
         lines.append("")
 
         # Detailed sections.
         if module.exports:
+            lines.append(f'<a name="{self.anchor(module.fully_qualified_name)}-exports"></a>')
             lines.append("#### Exports")
             lines.append("")
             for exp in module.exports:
-                lines.append(f"- `{exp}`")
+                # Hack since we have the fqn for a module as a string
+                fqn = f"{module.fully_qualified_name}.{exp}"
+                link = f"#{self.anchor(fqn)}" if is_one_file else f"{fqn}.md"
+                lines.append(f"- [`{exp}`]({link})")
             lines.append("")
         if module.constants:
             lines.append("#### Constants")
@@ -553,15 +548,15 @@ class MarkdownRenderer:
 
         return lines
 
-    def render_class_toc(self, cls: Class, indent: int) -> list[str]:
+    def render_class_toc(self, module: Module, cls: Class, indent: int) -> list[str]:
         """Render a TOC entry for a class and its nested classes."""
         lines: list[str] = []
         indent_str = "  " * indent
         lines.append(
-            f"{indent_str}- [{cls.name}](#{self.anchor(cls.fully_qualified_name)})"
+            f"{indent_str}- [{cls.name}]({self.link(module, cls)})",
         )
         for nested in cls.classes:
-            lines.extend(self.render_class_toc(nested, indent + 1))
+            lines.extend(self.render_class_toc(module, nested, indent + 1))
         return lines
 
     def render_class_details(self, cls: Class, level: int) -> list[str]:
@@ -679,6 +674,21 @@ class MarkdownRenderer:
         This implementation replaces dots with hyphens.
         """
         return fq_name.replace(".", "-")
+
+
+    def link(self, module: Module, item: DocumentedItem | None = None, is_in_file: bool = True) -> str:
+        """
+        Generate a link to a fully qualified name.
+        """
+        match (item, is_in_file):
+            case (None, True):
+                return f"#{self.anchor(module.fully_qualified_name)}"
+            case (None, False):
+                return f"{module.fully_qualified_name}.md"
+            case (item, True):
+                return f"#{self.anchor(item.fully_qualified_name)}"
+            case (item, False):
+                return f"{module.fully_qualified_name}.md#{self.anchor(item.fully_qualified_name)}"
 
 
 # --- Main function ---

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -584,10 +584,9 @@ class MarkdownRenderer:
                 lines.extend(self.render_function(func, level=level + 1))
             lines.append("")
         if cls.classes:
-            lines.append("**Nested Classes:**")
-            lines.append("")
+            # Flatten all nested classes in this class.
             for nested in cls.classes:
-                lines.extend(self.render_class_details(nested, level=level + 1))
+                lines.extend(self.render_class_details(nested, level=level))
             lines.append("")
         return lines
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -368,6 +368,20 @@ def reformat_docstring(doc: docstring_parser.Docstring | None, signature: str | 
         lines.append("```python")
         lines.append(signature)
         lines.append("```")
+    if doc.attrs:
+        lines.append("**Attributes:**")
+        lines.append("")
+        for attr in doc.attrs:
+            attr_line = f"- `{attr.arg_name}`"
+            if attr.type_name:
+                attr_line += f" (**{attr.type_name}**)"
+            attr_line += f": {attr.description}"
+            if attr.default:
+                attr_line += f" (default: `{attr.default}`)"
+            if attr.is_optional:
+                attr_line += " (optional)"
+            lines.append(attr_line)
+        lines.append("")
     if doc.params:
         lines.append("**Parameters:**")
         lines.append("")
@@ -378,6 +392,15 @@ def reformat_docstring(doc: docstring_parser.Docstring | None, signature: str | 
             param_line += f": {param.description}"
             lines.append(param_line)
         lines.append("")
+    if doc.examples:
+        lines.append("**Examples:**")
+        lines.append("")
+        for example in doc.examples:
+            if example.snippet:
+                lines.append("```python")
+                lines.append(example.snippet)
+                lines.append("```")
+                lines.append("")
     if doc.returns:
         lines.append("**Returns:**")
         lines.append("")

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -91,6 +91,7 @@ class Constant:
 
 # --- Helper functions ---
 
+
 def get_string_value(node: ast.AST) -> str | None:
     """Extract a string from an AST node representing a constant."""
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
@@ -348,6 +349,7 @@ def crawl_package(package_path: Path) -> Package:
 
 # --- Renderer Classes ---
 
+
 class Renderer:
     def render(self, package: Package) -> str:
         """Render the Package as a string.
@@ -596,6 +598,7 @@ class MarkdownRenderer(Renderer):
 
 
 # --- Main function ---
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -91,7 +91,6 @@ class Constant:
 
 # --- Helper functions ---
 
-
 def get_string_value(node: ast.AST) -> str | None:
     """Extract a string from an AST node representing a constant."""
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
@@ -349,7 +348,6 @@ def crawl_package(package_path: Path) -> Package:
 
 # --- Renderer Classes ---
 
-
 class Renderer:
     def render(self, package: Package) -> str:
         """Render the Package as a string.
@@ -358,9 +356,10 @@ class Renderer:
 
 
 class MarkdownRenderer(Renderer):
-    def __init__(self):
+    def __init__(self, include_private: bool = False):
         # List of tuples: (level, title, slug)
         self.toc: list[tuple[int, str, str]] = []
+        self.include_private = include_private
 
     @staticmethod
     def slugify(text: str) -> str:
@@ -370,6 +369,13 @@ class MarkdownRenderer(Renderer):
         text = re.sub(r"[^a-z0-9\s-]", "", text)
         text = re.sub(r"\s+", "-", text).strip("-")
         return text
+
+    def is_private(self, item: DocumentedItem) -> bool:
+        """Return True if the item is considered private."""
+        return not self.include_private and (
+            item.name.startswith("_")
+            and not (item.name.startswith("__") and item.name.endswith("__"))
+        )
 
     def render_docstring(
         self,
@@ -480,8 +486,10 @@ class MarkdownRenderer(Renderer):
 
     def render_constant(self, const: Constant, heading_level: int) -> list[str]:
         """Render a constant to Markdown and return the lines as a list of strings."""
+        # Skip if private.
+        if self.is_private(const):
+            return []
         lines = []
-        # Render constant header with its fully qualified name.
         lines.extend(self.render_header(heading_level, const))
         lines.append("")
         lines.append("```python")
@@ -495,9 +503,10 @@ class MarkdownRenderer(Renderer):
 
     def render_function(self, func: Function, heading_level: int) -> list[str]:
         """Render a function or method to Markdown and return the lines as a list of strings."""
+        if self.is_private(func):
+            return []
         doc = self.render_docstring(func.docstring, func.signature)
         lines = []
-        # For functions, override the header title to wrap the name in backticks.
         lines.extend(self.render_header(heading_level, func))
         lines.append("")
         if doc:
@@ -506,12 +515,9 @@ class MarkdownRenderer(Renderer):
         return lines
 
     def render_class(self, cls: Class, heading_level: int) -> list[str]:
-        """Recursively render a class, its signature, its methods, and nested classes.
-
-        Note: The header for the class is rendered before its children, so that it appears
-        correctly in the table of contents.
-        """
-        # Render the class header first.
+        """Recursively render a class, its signature, its methods, and nested classes."""
+        if self.is_private(cls):
+            return []
         md = []
         md.extend(self.render_header(heading_level, cls))
         md.append("")
@@ -519,9 +525,10 @@ class MarkdownRenderer(Renderer):
         if doc:
             md.append(doc)
             md.append("")
-        # Then render its children.
         child_lines = []
         for method in cls.functions:
+            if self.is_private(method):
+                continue
             rendered = self.render_function(method, heading_level=heading_level + 1)
             if rendered:
                 child_lines.extend(rendered)
@@ -535,7 +542,6 @@ class MarkdownRenderer(Renderer):
 
     def render_module(self, module: Module) -> list[str]:
         """Render a module and its children."""
-        # Render the module header first.
         lines = []
         lines.extend(self.render_header(2, module))
         lines.append("")
@@ -549,7 +555,6 @@ class MarkdownRenderer(Renderer):
                 lines.append(f"- `{export}`")
             lines.append("")
 
-        # Now render the children.
         children_lines = []
         for const in module.constants:
             rendered = self.render_constant(const, heading_level=3)
@@ -564,7 +569,6 @@ class MarkdownRenderer(Renderer):
             if rendered:
                 children_lines.extend(rendered)
                 children_lines.append("")
-
         lines.extend(children_lines)
         return lines
 
@@ -593,16 +597,15 @@ class MarkdownRenderer(Renderer):
 
 # --- Main function ---
 
-
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Crawl a Python package and extract docstrings."
     )
     parser.add_argument("package_path", help="Path to the Python package directory")
     parser.add_argument(
-        "--exclude_empty",
+        "--include-private",
         action="store_true",
-        help="Exclude items without docstrings (unless they have children with docstrings)",
+        help="Include private functions, classes, and constants (names starting with '_')",
     )
     args = parser.parse_args()
 
@@ -612,7 +615,7 @@ def main() -> None:
         return
 
     package = crawl_package(package_dir)
-    renderer = MarkdownRenderer()
+    renderer = MarkdownRenderer(include_private=args.include_private)
     markdown_output = renderer.render(package)
     print(markdown_output)
 

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -453,12 +453,7 @@ class MarkdownRenderer:
         level: int,
         item: DocumentedItem,
     ) -> list[str]:
-        """
-        Render a header using a documented data class.
-        Uses the item's name (slugified) as the anchor, and the title_override
-        if provided; otherwise uses the item's name.
-        Records the header in the TOC and returns a list of Markdown lines.
-        """
+        """Render a header using a documented data class."""
         slug = self.slugify(item.name)
         return [f'<a id="{slug}"></a>', f"{'#' * level} `{item.fully_qualified_name}`"]
 
@@ -626,7 +621,10 @@ class MarkdownRenderer:
                 raise ValueError(f"Unsupported root type: {type(root)}")
 
     def render_file(
-        self, root: Package | Module, path: Path, include_toc: bool = False
+        self,
+        root: Package | Module,
+        path: Path,
+        include_toc: bool = False,
     ) -> None:
         """Render the root object as Markdown and write it to a file."""
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -465,6 +465,7 @@ class MarkdownRenderer:
             # Render all modules
             for module in package.modules:
                 lines.extend(self.render_module(module, is_one_file=is_one_file))
+            lines.append("")
             output = "\n".join(lines)
             if output_path is None:
                 print(output)
@@ -477,10 +478,12 @@ class MarkdownRenderer:
             for module in package.modules:
                 file_name = self.link(module, is_in_file=is_one_file)
                 module_lines = self.render_module(module, is_one_file=is_one_file)
+                module_lines.append("")
                 module_output = "\n".join(module_lines)
                 file_path = output_path / file_name
                 file_path.write_text(module_output, encoding="utf8")
             # Write the index file table of contents linking to each module
+            lines.append("")
             (output_path / "index.md").write_text("\n".join(lines), encoding="utf8")
 
     def render_constant(self, const: Constant, level: int = 2) -> list[str]:

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -1,407 +1,567 @@
 #!/usr/bin/env python3
 """
 This script crawls a Python package directory, extracts docstrings from modules,
-classes, functions, and methods using the `ast` module, and writes the results
-to a single Markdown file.
+classes, functions, methods, and constants using the `ast` module, and stores them in the associated data classes.
 
 Additional features:
-  - Module names are shown as dotted names (e.g. "foo.bar.baz") rather than file paths.
-  - For each __init__.py, if an __all__ is defined, an Exports section is generated.
-  - Headers have descriptive HTML anchors derived from their dotted names.
+  - For each __init__.py, if an __all__ is defined, an exports list is generated.
+  - Headers have HTML anchors derived from the fully qualified names.
   - For each function/method, its signature is included with type hints (if present) and its return type.
   - Autodetects docstring formats (Google-style, NumPy-style, etc.) and reformats them into Markdown.
+  - Constants are detected and their types are included when available.
 """
+
+from __future__ import annotations
 
 import argparse
 import ast
-import os
 import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
 
 import docstring_parser
 
-# Global variables for the Table of Contents and anchors
-toc_entries = []  # List of tuples: (full_header_text, display_name, anchor)
-anchor_usage = {}  # To ensure unique anchors based on header text
+
+# Define a protocol for documented items that have a name and fully_qualified_name.
+class DocumentedItem(Protocol):
+    name: str
+    fully_qualified_name: str
 
 
-def _make_anchor(text):
-    """
-    Create a slug for the anchor by removing formatting,
-    lower-casing, and replacing non-alphanumeric characters with hyphens.
-    """
-    text = text.replace("`", "").lower()
-    text = re.sub(r"[^a-z0-9]+", "-", text)
-    return text.strip("-")
+@dataclass
+class Package:
+    path: Path
+    name: str  # final name (directory name)
+    fully_qualified_name: str  # same as name for the top-level package
+    modules: list[Module] = field(default_factory=list)
 
 
-def _add_header(full_header_text, provided_level):
-    """
-    Create a markdown header with a unique, descriptive anchor and record it for the TOC.
-    Instead of printing the full dotted name, only the stem (last segment) is used
-    for display.
-
-    Args:
-        full_header_text (str): The fully qualified dotted name.
-        provided_level (int): The markdown header level to use.
-
-    Returns:
-        list of str: Markdown lines for the header (including an HTML anchor).
-    """
-    display_name = full_header_text.split(".")[-1]
-    anchor_base = _make_anchor(full_header_text)
-    count = anchor_usage.get(anchor_base, 0)
-    if count:
-        anchor = f"{anchor_base}-{count+1}"
-    else:
-        anchor = anchor_base
-    anchor_usage[anchor_base] = count + 1
-
-    # Save the full name along with the display name and anchor.
-    toc_entries.append((full_header_text, display_name, anchor))
-    return [f'<a id="{anchor}"></a>', f'{"#" * provided_level} `{display_name}`']
+@dataclass
+class Module:
+    path: Path
+    name: str  # final module name (file stem)
+    fully_qualified_name: (
+        str  # e.g. package_name.module or just package_name for __init__
+    )
+    package: Package
+    docstring: docstring_parser.Docstring | None = None
+    constants: list[Constant] = field(default_factory=list)
+    functions: list[Function] = field(default_factory=list)
+    classes: list[Class] = field(default_factory=list)
+    exports: list[str] = field(default_factory=list)
 
 
-def _get_module_name(file_path, package_dir):
-    """
-    Convert a file path to a dotted module name relative to package_dir,
-    including the package’s base name.
-    For example, if package_dir is '/path/to/sample_package' and file_path is
-    '/path/to/sample_package/core.py', the returned module name is 'sample_package.core'.
-    For __init__.py, the "__init__" part is dropped.
-    """
-    rel_path = os.path.relpath(file_path, package_dir)
-    if rel_path.endswith(".py"):
-        rel_path = rel_path[:-3]  # remove ".py"
-    parts = rel_path.split(os.sep)
-    if parts[-1] == "__init__":
-        parts = parts[:-1]
-    package_name = os.path.basename(os.path.abspath(package_dir))
-    if not parts:
-        return package_name
-    return package_name + "." + ".".join(parts)
+@dataclass
+class Class:
+    path: Path
+    name: str  # final class name
+    fully_qualified_name: str  # e.g. foo.bar.Baz
+    parent: (
+        Module | Class
+    )  # Can be either a module or another class (for nested classes)
+    docstring: docstring_parser.Docstring | None = None
+    functions: list[Function] = field(default_factory=list)
+    classes: list[Class] = field(default_factory=list)  # For nested classes
 
 
-def _extract_all_from_ast(tree):
-    """
-    Look for an assignment to __all__ in the module AST and extract its value.
+@dataclass
+class Function:
+    path: Path
+    name: str  # final function/method name
+    fully_qualified_name: str  # e.g. foo.bar.Baz.method
+    signature: str
+    parent: Class | Module
+    docstring: docstring_parser.Docstring | None = None
 
-    Args:
-        tree (ast.Module): The parsed AST of the module.
 
-    Returns:
-        list of str or None: The list of exported names if found, otherwise None.
-    """
-    for node in tree.body:
+@dataclass
+class Constant:
+    path: Path
+    name: str  # constant name
+    fully_qualified_name: str  # e.g. foo.bar.MY_CONSTANT
+    value: str  # the string representation of the value
+    type: str | None = None  # the constant's type, if available
+
+
+# --- Helper functions ---
+
+
+def get_string_value(node: ast.AST) -> str | None:
+    """Extract a string from an AST node representing a constant."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def build_signature(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    """Construct a signature string for a function/method from its AST node."""
+    args = node.args
+    param_strings = []
+
+    # Process positional arguments (with or without defaults)
+    pos_args = args.args
+    num_defaults = len(args.defaults)
+    num_no_default = len(pos_args) - num_defaults
+    for i, arg in enumerate(pos_args):
+        param = arg.arg
+        if arg.annotation:
+            param += f": {ast.unparse(arg.annotation)}"
+        if i >= num_no_default:
+            default_val = args.defaults[i - num_no_default]
+            param += f" = {ast.unparse(default_val)}"
+        param_strings.append(param)
+
+    # Process variable positional arguments (*args)
+    if args.vararg:
+        vararg = f"*{args.vararg.arg}"
+        if args.vararg.annotation:
+            vararg += f": {ast.unparse(args.vararg.annotation)}"
+        param_strings.append(vararg)
+
+    # Process keyword-only arguments
+    for i, arg in enumerate(args.kwonlyargs):
+        param = arg.arg
+        if arg.annotation:
+            param += f": {ast.unparse(arg.annotation)}"
+        default = args.kw_defaults[i]
+        if default is not None:
+            param += f" = {ast.unparse(default)}"
+        param_strings.append(param)
+
+    # Process variable keyword arguments (**kwargs)
+    if args.kwarg:
+        kwarg = f"**{args.kwarg.arg}"
+        if args.kwarg.annotation:
+            kwarg += f": {ast.unparse(args.kwarg.annotation)}"
+        param_strings.append(kwarg)
+
+    params = ", ".join(param_strings)
+    ret = ""
+    if node.returns:
+        ret = f" -> {ast.unparse(node.returns)}"
+    return f"{node.name}({params}){ret}"
+
+
+def parse_function(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+    file_path: Path,
+    parent: Class | Module,
+) -> Function:
+    """Parse a function or method node into a Function dataclass instance."""
+    signature = build_signature(node)
+    raw_doc = ast.get_docstring(node)
+    parsed_doc = docstring_parser.parse(raw_doc) if raw_doc else None
+    fq_name = f"{parent.fully_qualified_name}.{node.name}"
+    return Function(
+        path=file_path,
+        name=node.name,
+        fully_qualified_name=fq_name,
+        signature=signature,
+        parent=parent,
+        docstring=parsed_doc,
+    )
+
+
+def parse_class(node: ast.ClassDef, parent: Module | Class, file_path: Path) -> Class:
+    """Parse a class node into a Class dataclass instance and process its methods and nested classes."""
+    raw_doc = ast.get_docstring(node)
+    parsed_doc = docstring_parser.parse(raw_doc) if raw_doc else None
+    fq_name = f"{parent.fully_qualified_name}.{node.name}"
+    cls = Class(
+        path=file_path,
+        name=node.name,
+        fully_qualified_name=fq_name,
+        parent=parent,
+        docstring=parsed_doc,
+        functions=[],
+        classes=[],
+    )
+    # Process methods and nested classes.
+    for child in node.body:
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            method = parse_function(child, file_path, parent=cls)
+            cls.functions.append(method)
+        elif isinstance(child, ast.ClassDef):
+            nested_cls = parse_class(child, parent=cls, file_path=file_path)
+            cls.classes.append(nested_cls)
+    return cls
+
+
+def parse_module_docstring(module_ast: ast.Module) -> docstring_parser.Docstring | None:
+    """Extract and parse the module docstring."""
+    raw_doc = ast.get_docstring(module_ast)
+    return docstring_parser.parse(raw_doc) if raw_doc else None
+
+
+def parse_module_exports(module_ast: ast.Module) -> list[str]:
+    """Extract __all__ exports from an __init__.py module if present."""
+    exports: list[str] = []
+    for node in module_ast.body:
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and target.id == "__all__":
                     if isinstance(node.value, (ast.List, ast.Tuple)):
-                        items = []
                         for elt in node.value.elts:
-                            if isinstance(elt, ast.Str):
-                                items.append(elt.s)
-                            elif (
-                                hasattr(ast, "Constant")
-                                and isinstance(elt, ast.Constant)
-                                and isinstance(elt.value, str)
-                            ):
-                                items.append(elt.value)
-                        return items
-    return None
+                            value = get_string_value(elt)
+                            if value:
+                                exports.append(value)
+                    break
+    return exports
 
 
-def _get_function_signature(node):
+def parse_module_constants(
+    module_ast: ast.Module, module: Module, file_path: Path
+) -> None:
+    """Parse constants defined in a module.
+
+    A constant is considered any assignment at module level whose target is a Name in ALL CAPS,
+    excluding __all__. Supports both regular assignments (with optional type comments)
+    and annotated assignments.
     """
-    Build a string representation of the function/method signature,
-    including parameter type hints and the return type.
-
-    Note: Default values are not included.
-
-    Args:
-        node (ast.FunctionDef or ast.AsyncFunctionDef): The function node.
-
-    Returns:
-        str: A signature string, e.g.:
-             def func(arg1: int, arg2: str, *args: Any, **kwargs: Any) -> bool:
-    """
-    args_list = []
-    posonly = getattr(node.args, "posonlyargs", [])
-    for arg in posonly:
-        if arg.annotation is not None:
-            annotation_str = ast.unparse(arg.annotation)
-            args_list.append(f"{arg.arg}: {annotation_str}")
-        else:
-            args_list.append(arg.arg)
-    if posonly:
-        args_list.append("/")
-    for arg in node.args.args:
-        if arg.annotation is not None:
-            annotation_str = ast.unparse(arg.annotation)
-            args_list.append(f"{arg.arg}: {annotation_str}")
-        else:
-            args_list.append(arg.arg)
-    if node.args.vararg:
-        vararg = node.args.vararg
-        if vararg.annotation is not None:
-            annotation_str = ast.unparse(vararg.annotation)
-            args_list.append(f"*{vararg.arg}: {annotation_str}")
-        else:
-            args_list.append("*" + vararg.arg)
-    elif node.args.kwonlyargs:
-        args_list.append("*")
-    for arg in node.args.kwonlyargs:
-        if arg.annotation is not None:
-            annotation_str = ast.unparse(arg.annotation)
-            args_list.append(f"{arg.arg}: {annotation_str}")
-        else:
-            args_list.append(arg.arg)
-    if node.args.kwarg:
-        kwarg = node.args.kwarg
-        if kwarg.annotation is not None:
-            annotation_str = ast.unparse(kwarg.annotation)
-            args_list.append(f"**{kwarg.arg}: {annotation_str}")
-        else:
-            args_list.append("**" + kwarg.arg)
-    signature = f"def {node.name}({', '.join(args_list)})"
-    if node.returns is not None:
-        return_type_str = ast.unparse(node.returns)
-        signature += f" -> {return_type_str}"
-    signature += ":"
-    return signature
+    for node in module_ast.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            # Process ast.Assign nodes (may have multiple targets).
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if (
+                        isinstance(target, ast.Name)
+                        and target.id.isupper()
+                        and target.id != "__ALL__"
+                    ):
+                        type_annotation = None
+                        if hasattr(node, "type_comment") and node.type_comment:
+                            type_annotation = node.type_comment
+                        value = ast.unparse(node.value)
+                        fq_name = f"{module.fully_qualified_name}.{target.id}"
+                        constant = Constant(
+                            path=file_path,
+                            name=target.id,
+                            fully_qualified_name=fq_name,
+                            value=value,
+                            type=type_annotation,
+                        )
+                        module.constants.append(constant)
+                        break
+            # Process annotated assignments.
+            elif isinstance(node, ast.AnnAssign):
+                if (
+                    isinstance(node.target, ast.Name)
+                    and node.target.id.isupper()
+                    and node.target.id != "__ALL__"
+                ):
+                    type_annotation = (
+                        ast.unparse(node.annotation) if node.annotation else None
+                    )
+                    value = (
+                        ast.unparse(node.value) if node.value is not None else "None"
+                    )
+                    fq_name = f"{module.fully_qualified_name}.{node.target.id}"
+                    constant = Constant(
+                        path=file_path,
+                        name=node.target.id,
+                        fully_qualified_name=fq_name,
+                        value=value,
+                        type=type_annotation,
+                    )
+                    module.constants.append(constant)
 
 
-def _format_docstring(docstring):
-    """
-    Parse a docstring and reformat its components as Markdown.
+def parse_module_functions(
+    module_ast: ast.Module, module: Module, file_path: Path
+) -> None:
+    """Parse top-level functions in a module."""
+    for node in module_ast.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            func = parse_function(node, file_path, parent=module)
+            module.functions.append(func)
 
-    Args:
-        docstring (str): The raw docstring.
 
-    Returns:
-        str: The formatted Markdown version of the docstring.
-    """
-    parsed = docstring_parser.parse(
-        docstring, style=docstring_parser.DocstringStyle.AUTO
+def parse_module_classes(
+    module_ast: ast.Module, module: Module, file_path: Path
+) -> None:
+    """Parse classes in a module."""
+    for node in module_ast.body:
+        if isinstance(node, ast.ClassDef):
+            cls = parse_class(node, parent=module, file_path=file_path)
+            module.classes.append(cls)
+
+
+def parse_module(file_path: Path, package: Package) -> Module:
+    """Parse a single module file into a Module dataclass instance."""
+    with file_path.open("r", encoding="utf8") as f:
+        source = f.read()
+    module_ast = ast.parse(source, filename=str(file_path))
+    # If the file is __init__.py, use the package's fully qualified name.
+    mod_name = file_path.stem
+    if mod_name == "__init__":
+        fq_name = package.fully_qualified_name
+    else:
+        fq_name = f"{package.fully_qualified_name}.{mod_name}"
+    module = Module(
+        path=file_path,
+        name=mod_name,
+        fully_qualified_name=fq_name,
+        package=package,
+        docstring=parse_module_docstring(module_ast),
+        constants=[],
+        functions=[],
+        classes=[],
+        exports=[],
     )
+    if file_path.name == "__init__.py":
+        module.exports = parse_module_exports(module_ast)
+    parse_module_constants(module_ast, module, file_path)
+    parse_module_functions(module_ast, module, file_path)
+    parse_module_classes(module_ast, module, file_path)
+    return module
 
+
+def crawl_package(package_path: Path) -> Package:
+    """Recursively crawl the package directory, parsing each .py file as a Module."""
+    pkg_name = package_path.name
+    package = Package(
+        path=package_path, name=pkg_name, fully_qualified_name=pkg_name, modules=[]
+    )
+    for file_path in package_path.rglob("*.py"):
+        module = parse_module(file_path, package)
+        package.modules.append(module)
+    return package
+
+
+def reformat_docstring(doc: docstring_parser.Docstring | None) -> str:
+    """
+    Reformat the parsed docstring into Markdown.
+    This implementation produces Markdown by concatenating the short and long descriptions,
+    and listing parameters, return info, and exceptions.
+    """
+    if doc is None:
+        return ""
     lines = []
-    if parsed.short_description:
-        lines.append(parsed.short_description.strip())
-    if parsed.long_description:
+    if doc.short_description:
+        lines.append(doc.short_description)
+    if doc.long_description:
         lines.append("")
-        lines.append(parsed.long_description.strip())
-    if parsed.params:
+        lines.append(doc.long_description)
+    if doc.params:
         lines.append("")
-        lines.append("**Args:**")
+        lines.append("**Parameters:**")
+        for param in doc.params:
+            lines.append(f"- **{param.arg_name}**: {param.description}")
+    if doc.returns:
         lines.append("")
-        for param in parsed.params:
-            type_part = f" (*{param.type_name.strip()}*)" if param.type_name else ""
-            description_part = (
-                f": {param.description.strip()}" if param.description else ""
-            )
-            lines.append(f"- `{param.arg_name.strip()}`{type_part}{description_part}")
-    if parsed.returns:
-        lines.append("")
-        type_part = (
-            f" (*{parsed.returns.type_name.strip()}*)"
-            if parsed.returns.type_name
-            else ""
-        )
-        description_part = (
-            f" {parsed.returns.description.strip()}"
-            if parsed.returns.description
-            else ""
-        )
-        lines.append(f"**Returns:**{type_part}{description_part}")
-    if parsed.raises:
+        lines.append("**Returns:**")
+        lines.append(f"- {doc.returns.description}")
+    if doc.raises:
         lines.append("")
         lines.append("**Raises:**")
+        for exception in doc.raises:
+            lines.append(f"- **{exception.type_name}**: {exception.description}")
+    return "\n".join(lines).strip()
+
+
+# --- Renderer Classes ---
+
+
+class Renderer:
+    def render(self, package: Package) -> str:
+        """Render the Package as a string.
+        This method should be implemented by subclasses."""
+        raise NotImplementedError
+
+
+class MarkdownRenderer(Renderer):
+    def __init__(self, exclude_empty: bool = False):
+        # List of tuples: (level, title, slug)
+        self.toc: list[tuple[int, str, str]] = []
+        self.exclude_empty = exclude_empty
+
+    @staticmethod
+    def slugify(text: str) -> str:
+        """Convert text to a slug suitable for use as an anchor."""
+        text = text.lower()
+        text = text.replace(".", "-")  # Replace dots with dashes.
+        text = re.sub(r"[^a-z0-9\s-]", "", text)
+        text = re.sub(r"\s+", "-", text).strip("-")
+        return text
+
+    def render_header(
+        self, level: int, item: DocumentedItem, title_override: str | None = None
+    ) -> list[str]:
+        """
+        Render a header using a documented data class.
+        Uses the item's fully qualified name (slugified) as the anchor, and the title_override
+        if provided; otherwise uses the item's name.
+        Records the header in the TOC and returns a list of Markdown lines.
+        """
+        title = title_override if title_override is not None else item.name
+        slug = self.slugify(item.fully_qualified_name)
+        self.toc.append((level, title, slug))
+        return [f'<a id="{slug}"></a>', f"{'#' * level} {title}"]
+
+    def render_toc(self) -> list[str]:
+        """Render the table of contents based on the collected headers."""
+        lines = []
+        title = "Table of Contents"
+        slug = self.slugify(title)
+        lines.append(f'<a id="{slug}"></a>')
+        lines.append(f"### {title}")
         lines.append("")
-        for exc in parsed.raises:
-            type_part = f"(*{exc.type_name.strip()}*) " if exc.type_name else ""
-            description_part = exc.description.strip() if exc.description else ""
-            lines.append(f"- {type_part}{description_part}")
-    return "\n".join(lines)
-
-
-def _extract_docstrings_from_node(node, parent_qualname, heading_level=2):
-    """
-    Recursively extract docstrings from an AST node using fully qualified dotted names.
-    For functions and methods, the signature (with type hints) is included.
-    Docstrings are parsed (as Google-style) and reformatted into Markdown.
-
-    Args:
-        node (ast.AST): The AST node (e.g. Module, ClassDef, FunctionDef).
-        parent_qualname (str): The fully qualified name of the parent (module or class).
-        heading_level (int): The markdown header level to use.
-
-    Returns:
-        list of str: Lines of markdown documenting the node.
-    """
-    lines = []
-
-    if isinstance(node, ast.Module):
-        module_doc = ast.get_docstring(node)
-        if module_doc:
-            lines.append(_format_docstring(module_doc))
-            lines.append("")
-        for child in node.body:
-            lines.extend(
-                _extract_docstrings_from_node(child, parent_qualname, heading_level)
-            )
-        if lines:
-            # Remove final trainling line to prevent \n\n
-            lines.pop()
+        for level, title, slug in self.toc:
+            indent = "  " * (level - 1)
+            lines.append(f"{indent}- [{title}](#{slug})")
+        lines.append("")
         return lines
 
-    if isinstance(node, ast.ClassDef):
-        # Skip private and special classes (starting with underscore)
-        if node.name.startswith("_") and not node.name.startswith("__"):
-            return lines
-
-        qname = f"{parent_qualname}.{node.name}" if parent_qualname else node.name
-        lines.extend(_add_header(qname, provided_level=heading_level + 1))
+    def render_constant(self, const: Constant, heading_level: int) -> list[str]:
+        """Render a constant to Markdown and return the lines as a list of strings."""
+        lines = []
+        # Render constant header with its fully qualified name.
+        lines.extend(
+            self.render_header(heading_level, const, title_override=f"`{const.name}`")
+        )
         lines.append("")
-        class_doc = ast.get_docstring(node)
-        if class_doc:
-            lines.append(_format_docstring(class_doc))
-            lines.append("")
-        for child in node.body:
-            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                lines.extend(
-                    _extract_docstrings_from_node(child, qname, heading_level + 1)
-                )
-        return lines
-
-    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-        # Skip private and special functions (starting with underscore)
-        if node.name.startswith("_") and not node.name.startswith("__"):
-            return lines
-
-        qname = f"{parent_qualname}.{node.name}" if parent_qualname else node.name
-        lines.extend(_add_header(qname, provided_level=heading_level + 1))
-        lines.append("")
-        signature = _get_function_signature(node)
         lines.append("```python")
-        lines.append(signature)
+        if const.type:
+            lines.append(f"{const.name}: {const.type} = {const.value}")
+        else:
+            lines.append(f"{const.name} = {const.value}")
         lines.append("```")
         lines.append("")
-        func_doc = ast.get_docstring(node)
-        if func_doc:
-            lines.append(_format_docstring(func_doc))
+        return lines
+
+    def render_function(self, func: Function, heading_level: int) -> list[str]:
+        """Render a function or method to Markdown and return the lines as a list of strings."""
+        doc = reformat_docstring(func.docstring)
+        if self.exclude_empty and not doc:
+            return []
+        lines = []
+        # For functions, override the header title to wrap the name in backticks.
+        lines.extend(
+            self.render_header(heading_level, func, title_override=f"`{func.name}`")
+        )
+        lines.append("")
+        lines.append("```python")
+        lines.append(func.signature)
+        lines.append("```")
+        lines.append("")
+        if doc:
+            lines.append("**Docstring:**")
+            lines.append("")
+            lines.append(doc)
             lines.append("")
         return lines
 
-    return lines
+    def render_class(self, cls: Class, heading_level: int) -> list[str]:
+        """Recursively render a class, its methods, and nested classes."""
+        child_lines = []
+        for method in cls.functions:
+            rendered = self.render_function(method, heading_level=heading_level + 1)
+            if rendered:
+                child_lines.extend(rendered)
+        for nested in cls.classes:
+            rendered = self.render_class(nested, heading_level=heading_level + 1)
+            if rendered:
+                child_lines.extend(rendered)
+                child_lines.append("")
+        doc = reformat_docstring(cls.docstring)
+        if self.exclude_empty and not doc and not child_lines:
+            return []
+        md = []
+        md.extend(self.render_header(heading_level, cls))
+        md.append("")
+        if doc:
+            md.append("**Docstring:**")
+            md.append("")
+            md.append(doc)
+            md.append("")
+        md.extend(child_lines)
+        return md
+
+    def render_module(self, module: Module) -> list[str]:
+        """Render a module and its children."""
+        children_lines = []
+        for const in module.constants:
+            rendered = self.render_constant(const, heading_level=3)
+            if rendered:
+                children_lines.extend(rendered)
+        for func in module.functions:
+            rendered = self.render_function(func, heading_level=3)
+            if rendered:
+                children_lines.extend(rendered)
+        for cls in module.classes:
+            rendered = self.render_class(cls, heading_level=3)
+            if rendered:
+                children_lines.extend(rendered)
+                children_lines.append("")
+        module_doc = reformat_docstring(module.docstring)
+        if (
+            self.exclude_empty
+            and not module_doc
+            and not module.exports
+            and not children_lines
+        ):
+            return []
+        lines = []
+        lines.extend(self.render_header(2, module))
+        lines.append("")
+        if module_doc:
+            lines.append(module_doc)
+            lines.append("")
+        if module.exports:
+            for export in module.exports:
+                lines.append(f"- `{export}`")
+            lines.append("")
+        lines.extend(children_lines)
+        return lines
+
+    def render(self, package: Package) -> str:
+        """
+        Render the Package as a Markdown string.
+        The table of contents is inserted immediately after the package header.
+        """
+        self.toc = []
+        package_header = self.render_header(1, package)
+        modules_lines: list[str] = []
+        for module in package.modules:
+            rendered_module = self.render_module(module)
+            if rendered_module:
+                modules_lines.extend(rendered_module)
+        toc_lines = self.render_toc()
+        final_lines = []
+        final_lines.extend(package_header)
+        final_lines.append("")
+        final_lines.extend(toc_lines)
+        final_lines.append("---")
+        final_lines.append("")
+        final_lines.extend(modules_lines)
+        return "\n".join(final_lines)
 
 
-def _process_file(file_path, package_dir):
-    """
-    Process a single Python file to extract its documentation as markdown text.
-    If the file is an __init__.py, also extract its __all__.
-    """
-    try:
-        with open(file_path, "r", encoding="utf8") as f:
-            source = f.read()
-        tree = ast.parse(source, filename=file_path)
-    except Exception as e:
-        print(f"Error processing {file_path}: {e}")
-        return ""
-
-    module_name = _get_module_name(file_path, package_dir)
-    package_name = os.path.basename(os.path.abspath(package_dir))
-    # Use heading level 1 for the root package; otherwise, indent based on the dot count.
-    if module_name == package_name:
-        heading_level = 1
-    else:
-        heading_level = 1 + module_name.count(".")
-
-    md_lines = []
-    md_lines.extend(_add_header(module_name, provided_level=heading_level))
-    md_lines.append("")
-    md_lines.extend(
-        _extract_docstrings_from_node(
-            tree, parent_qualname=module_name, heading_level=2
-        )
-    )
-    md_lines.append("")
-    if os.path.basename(file_path) == "__init__.py":
-        if exports := _extract_all_from_ast(tree):
-            md_lines.append("**Exports:**")
-            md_lines.append("")
-            for export in exports:
-                md_lines.append(f"- `{export}`")
-            md_lines.append("")
-    return "\n".join(md_lines)
+# --- Main function ---
 
 
-def crawl(directory):
-    """
-    Recursively crawl a directory, process each Python file, and generate
-    the complete markdown documentation.
-
-    Args:
-        directory (str): The root directory to crawl.
-
-    Returns:
-        str: The complete markdown documentation for the entire package,
-             including table of contents and exports section.
-    """
-    # Process all Python files
-    all_docs = []
-    for root, _, files in os.walk(directory):
-        for file in sorted(files):
-            if file.endswith(".py"):
-                file_path = os.path.join(root, file)
-                print(f"Processing {file_path}...")
-                file_docs = _process_file(file_path, directory)
-                if file_docs:
-                    all_docs.append(file_docs)
-    docs_content = "\n".join(all_docs)
-
-    # Generate the complete documentation
-    final_lines = []
-    final_lines.append("# Documentation")
-    final_lines.append("")
-    final_lines.extend(_generate_toc())
-    final_lines.append(docs_content)
-
-    return "\n".join(final_lines)
-
-
-def _generate_toc():
-    """
-    Generate a Markdown-formatted Table of Contents.
-    The TOC uses the stored full name (to compute indentation based on the number of dots)
-    while displaying only the stem name.
-    """
-    lines = []
-    lines.append("## Table of Contents")
-    lines.append("")
-    for full_name, display_name, anchor in toc_entries:
-        indent = "  " * full_name.count(".")
-        lines.append(f"{indent}- [`{display_name}`](#{anchor})")
-    lines.append("")
-    return lines
-
-
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Generate a Markdown documentation file from a Python package directory."
+        description="Crawl a Python package and extract docstrings."
     )
-    parser.add_argument("package_dir", help="Path to the Python package directory")
-    parser.add_argument("output_file", help="Path to the output Markdown file")
+    parser.add_argument("package_path", help="Path to the Python package directory")
+    parser.add_argument(
+        "--exclude_empty",
+        action="store_true",
+        help="Exclude items without docstrings (unless they have children with docstrings)",
+    )
     args = parser.parse_args()
 
-    try:
-        content = crawl(args.package_dir)
-        with open(args.output_file, "w", encoding="utf8") as f:
-            f.write(content)
-        print(
-            f"Documentation successfully generated and saved to '{args.output_file}'."
-        )
-    except Exception as e:
-        print(f"Error writing to output file: {e}")
+    package_dir = Path(args.package_path)
+    if not package_dir.is_dir():
+        print(f"Error: {package_dir} is not a directory.")
+        return
+
+    package = crawl_package(package_dir)
+    renderer = MarkdownRenderer(exclude_empty=args.exclude_empty)
+    markdown_output = renderer.render(package)
+    print(markdown_output)
 
 
 if __name__ == "__main__":

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -431,6 +431,17 @@ def crawl_package(package_path: Path, include_private: bool = False) -> Package:
 # --- Renderer Classes ---
 
 
+_MARKDOWN_CHARACTERS_TO_ESCAPE = set(r"\`*_{}[]<>()#+.!|")
+
+
+# From https://stackoverflow.com/questions/68699165/how-to-escape-texts-for-formatting-in-python
+def escaped_markdown(text: str) -> str:
+    return "".join(
+        f"\\{character}" if character in _MARKDOWN_CHARACTERS_TO_ESCAPE else character
+        for character in text.strip()
+    )
+
+
 class MarkdownRenderer:
     def render(self, package: Package, output_path: Path | None = None) -> None:
         """
@@ -633,10 +644,10 @@ class MarkdownRenderer:
         indent_str = "  " * indent
         lines: list[str] = []
         if doc.short_description:
-            lines.append(f"{indent_str}{doc.short_description.strip()}")
+            lines.append(f"{indent_str}{escaped_markdown(doc.short_description)}")
             lines.append("")
         if doc.long_description:
-            lines.append(f"{indent_str}{doc.long_description.strip()}")
+            lines.append(f"{indent_str}{escaped_markdown(doc.long_description)}")
             lines.append("")
         if doc.params:
             lines.append(f"{indent_str}**Parameters:**")
@@ -648,7 +659,7 @@ class MarkdownRenderer:
                 if param.default:
                     line += f" (default: `{param.default}`)"
                 if param.description:
-                    line += f": {param.description.strip()}"
+                    line += f": {escaped_markdown(param.description)}"
                 lines.append(line)
             lines.append("")
         if doc.attrs:
@@ -659,7 +670,7 @@ class MarkdownRenderer:
                 if attr.type_name:
                     line += f" (`{attr.type_name}`)"
                 if attr.description:
-                    line += f": {attr.description.strip()}"
+                    line += f": {escaped_markdown(attr.description)}"
                 lines.append(line)
             lines.append("")
         if doc.returns:
@@ -669,7 +680,7 @@ class MarkdownRenderer:
             if doc.returns.type_name:
                 ret_line += f"`{doc.returns.type_name}`: "
             if doc.returns.description:
-                ret_line += f"{doc.returns.description.strip()}"
+                ret_line += f"{escaped_markdown(doc.returns.description)}"
             else:
                 # Trim the trailing colon if no description is provided.
                 ret_line = ret_line[:-2]
@@ -681,7 +692,7 @@ class MarkdownRenderer:
             for raise_item in doc.raises:
                 raise_line = f"{indent_str}- **{raise_item.type_name}**: "
                 if raise_item.description:
-                    raise_line += f"{raise_item.description.strip()}"
+                    raise_line += f"{escaped_markdown(raise_item.description)}"
                 else:
                     raise_line = raise_line[:-2]
                 lines.append(raise_line)

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -447,7 +447,7 @@ class MarkdownRenderer:
         lines.append("")
         for module in package.modules:
             link = self.link(module, is_in_file=is_one_file)
-            lines.append(f"- [{module.fully_qualified_name}]({link})")
+            lines.append(f"- 🅼 [{module.fully_qualified_name}]({link})")
         lines.append("")
 
         if is_one_file:
@@ -484,7 +484,7 @@ class MarkdownRenderer:
         header_prefix = "#" * level
         # Module header with an HTML anchor.
         lines.append(f'<a name="{self.anchor(module.fully_qualified_name)}"></a>')
-        lines.append(f"{header_prefix} {module.fully_qualified_name}")
+        lines.append(f"{header_prefix} 🅼 {module.fully_qualified_name}")
         lines.append("")
 
         # Render module docstring details if available.
@@ -496,11 +496,11 @@ class MarkdownRenderer:
         if module.constants:
             lines.append("- **Constants:**")
             for const in module.constants:
-                lines.append("  " * 1 + f"- [{const.name}]({self.link(module, const)})")
+                lines.append("  " * 1 + f"- 🆅 [{const.name}]({self.link(module, const)})")
         if module.functions:
             lines.append("- **Functions:**")
             for func in module.functions:
-                lines.append("  " * 1 + f"- [{func.name}]({self.link(module, func)})")
+                lines.append("  " * 1 + f"- 🅵 [{func.name}]({self.link(module, func)})")
         if module.classes:
             lines.append("- **Classes:**")
             for cls in module.classes:
@@ -545,7 +545,7 @@ class MarkdownRenderer:
                 # Hack since we have the fqn for a module as a string
                 fqn = f"{module.fully_qualified_name}.{exp}"
                 link = f"#{self.anchor(fqn)}" if is_one_file else f"{fqn}.md"
-                lines.append(f"- [`{exp}`]({link})")
+                lines.append(f"- 🅼 [`{exp}`]({link})")
             lines.append("")
 
         return lines
@@ -555,7 +555,7 @@ class MarkdownRenderer:
         lines: list[str] = []
         indent_str = "  " * indent
         lines.append(
-            f"{indent_str}- [{cls.name}]({self.link(module, cls)})",
+            f"{indent_str}- 🅲 [{cls.name}]({self.link(module, cls)})",
         )
         for nested in cls.classes:
             lines.extend(self.render_class_toc(module, nested, indent + 1))
@@ -569,7 +569,7 @@ class MarkdownRenderer:
         lines: list[str] = []
         header_prefix = "#" * level
         lines.append(f'<a name="{self.anchor(cls.fully_qualified_name)}"></a>')
-        lines.append(f"{header_prefix} {cls.fully_qualified_name}")
+        lines.append(f"{header_prefix} 🅲 {cls.fully_qualified_name}")
         lines.append("")
         lines.append("```python")
         lines.append(cls.signature)
@@ -578,7 +578,7 @@ class MarkdownRenderer:
         if cls.docstring:
             lines.extend(self.render_docstring(cls.docstring))
         if cls.functions:
-            lines.append("**Methods:**")
+            lines.append("**Functions:**")
             lines.append("")
             for func in cls.functions:
                 lines.extend(self.render_function(func, level=level + 1))
@@ -599,7 +599,7 @@ class MarkdownRenderer:
         lines: list[str] = []
         header_prefix = "#" * level
         lines.append(f'<a name="{self.anchor(func.fully_qualified_name)}"></a>')
-        lines.append(f"{header_prefix} {func.fully_qualified_name}")
+        lines.append(f"{header_prefix} 🅵 {func.fully_qualified_name}")
         lines.append("")
         lines.append("```python")
         lines.append(func.signature)

--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -347,63 +347,6 @@ def crawl_package(package_path: Path) -> Package:
     return package
 
 
-def reformat_docstring(doc: docstring_parser.Docstring | None, signature: str | None = None) -> str:
-    """
-    Reformat the parsed docstring into Markdown.
-    This implementation produces Markdown by concatenating the short and long descriptions,
-    and listing parameters (with types if available), return info (with type), and exceptions.
-    """
-    if doc is None:
-        return ""
-    lines = []
-    if doc.short_description:
-        lines.append(doc.short_description)
-        lines.append("")
-    if doc.long_description:
-        lines.append(doc.long_description)
-        lines.append("")
-    if signature:
-        lines.append("**Signature:**")
-        lines.append("")
-        lines.append("```python")
-        lines.append(signature)
-        lines.append("```")
-    if doc.params:
-        lines.append("**Parameters:**")
-        lines.append("")
-        for param in doc.params:
-            param_line = f"- `{param.arg_name}`"
-            if param.type_name:
-                param_line += f" (**{param.type_name}**)"
-            param_line += f": {param.description}"
-            lines.append(param_line)
-        lines.append("")
-    if doc.examples:
-        lines.append("**Examples:**")
-        lines.append("")
-        for example in doc.examples:
-            if example.snippet:
-                lines.append("```python")
-                lines.append(example.snippet)
-                lines.append("```")
-                lines.append("")
-    if doc.returns:
-        lines.append("**Returns:**")
-        lines.append("")
-        ret_line = "- "
-        if doc.returns.type_name:
-            ret_line += f"(**{doc.returns.type_name}**) "
-        ret_line += f"{doc.returns.description}"
-        lines.append(ret_line)
-        lines.append("")
-    if doc.raises:
-        lines.append("**Raises:**")
-        for exception in doc.raises:
-            lines.append(f"- (**{exception.type_name}**) {exception.description}")
-        lines.append("")
-    return "\n".join(lines).strip()
-
-
 # --- Renderer Classes ---
 
 
@@ -427,6 +370,66 @@ class MarkdownRenderer(Renderer):
         text = re.sub(r"[^a-z0-9\s-]", "", text)
         text = re.sub(r"\s+", "-", text).strip("-")
         return text
+
+    def render_docstring(
+        self,
+        doc: docstring_parser.Docstring | None,
+        signature: str | None = None,
+    ) -> str:
+        """
+        Reformat the parsed docstring into Markdown.
+        This implementation produces Markdown by concatenating the short and long descriptions,
+        and listing parameters (with types if available), return info (with type), and exceptions.
+        """
+        if doc is None:
+            return ""
+        lines = []
+        if doc.short_description:
+            lines.append(doc.short_description)
+            lines.append("")
+        if doc.long_description:
+            lines.append(doc.long_description)
+            lines.append("")
+        if signature:
+            lines.append("**Signature:**")
+            lines.append("")
+            lines.append("```python")
+            lines.append(signature)
+            lines.append("```")
+        if doc.params:
+            lines.append("**Parameters:**")
+            lines.append("")
+            for param in doc.params:
+                param_line = f"- `{param.arg_name}`"
+                if param.type_name:
+                    param_line += f" (**{param.type_name}**)"
+                param_line += f": {param.description}"
+                lines.append(param_line)
+            lines.append("")
+        if doc.examples:
+            lines.append("**Examples:**")
+            lines.append("")
+            for example in doc.examples:
+                if example.snippet:
+                    lines.append("```python")
+                    lines.append(example.snippet)
+                    lines.append("```")
+                    lines.append("")
+        if doc.returns:
+            lines.append("**Returns:**")
+            lines.append("")
+            ret_line = "- "
+            if doc.returns.type_name:
+                ret_line += f"(**{doc.returns.type_name}**) "
+            ret_line += f"{doc.returns.description}"
+            lines.append(ret_line)
+            lines.append("")
+        if doc.raises:
+            lines.append("**Raises:**")
+            for exception in doc.raises:
+                lines.append(f"- (**{exception.type_name}**) {exception.description}")
+            lines.append("")
+        return "\n".join(lines).strip()
 
     def render_header(
         self,
@@ -474,7 +477,7 @@ class MarkdownRenderer(Renderer):
 
     def render_function(self, func: Function, heading_level: int) -> list[str]:
         """Render a function or method to Markdown and return the lines as a list of strings."""
-        doc = reformat_docstring(func.docstring, func.signature)
+        doc = self.render_docstring(func.docstring, func.signature)
         lines = []
         # For functions, override the header title to wrap the name in backticks.
         lines.extend(self.render_header(heading_level, func))
@@ -494,7 +497,7 @@ class MarkdownRenderer(Renderer):
         md = []
         md.extend(self.render_header(heading_level, cls))
         md.append("")
-        doc = reformat_docstring(cls.docstring, cls.signature)
+        doc = self.render_docstring(cls.docstring, cls.signature)
         if doc:
             md.append(doc)
             md.append("")
@@ -519,7 +522,7 @@ class MarkdownRenderer(Renderer):
         lines.extend(self.render_header(2, module))
         lines.append("")
 
-        module_doc = reformat_docstring(module.docstring)
+        module_doc = self.render_docstring(module.docstring)
         if module_doc:
             lines.append(module_doc)
             lines.append("")

--- a/tests/data/DOCUMENTATION.md
+++ b/tests/data/DOCUMENTATION.md
@@ -1,475 +1,577 @@
-# Documentation
+# `sample_package`
 
 ## Table of Contents
 
-- [`sample_package`](#sample-package)
-  - [`core`](#sample-package-core)
-    - [`DataProcessor`](#sample-package-core-dataprocessor)
-      - [`__init__`](#sample-package-core-dataprocessor-init)
-      - [`Config`](#sample-package-core-dataprocessor-config)
-        - [`__init__`](#sample-package-core-dataprocessor-config-init)
-        - [`update`](#sample-package-core-dataprocessor-config-update)
-      - [`process`](#sample-package-core-dataprocessor-process)
-    - [`batch_process`](#sample-package-core-batch-process)
-  - [`models`](#sample-package-models)
-    - [`BaseModel`](#sample-package-models-basemodel)
-      - [`to_dict`](#sample-package-models-basemodel-to-dict)
-    - [`User`](#sample-package-models-user)
-      - [`__init__`](#sample-package-models-user-init)
-      - [`to_dict`](#sample-package-models-user-to-dict)
-  - [`utils`](#sample-package-utils)
-    - [`load_json`](#sample-package-utils-load-json)
-    - [`validate_data`](#sample-package-utils-validate-data)
-    - [`ValidationError`](#sample-package-utils-validationerror)
-      - [`__init__`](#sample-package-utils-validationerror-init)
-  - [`exotic`](#sample-package-exotic)
-    - [`advanced_types`](#sample-package-exotic-advanced-types)
-      - [`Serializable`](#sample-package-exotic-advanced-types-serializable)
-        - [`__init__`](#sample-package-exotic-advanced-types-serializable-init)
-        - [`serialize`](#sample-package-exotic-advanced-types-serializable-serialize)
-    - [`descriptors`](#sample-package-exotic-descriptors)
-      - [`ValidatedField`](#sample-package-exotic-descriptors-validatedfield)
-        - [`__init__`](#sample-package-exotic-descriptors-validatedfield-init)
-        - [`__get__`](#sample-package-exotic-descriptors-validatedfield-get)
-        - [`__set__`](#sample-package-exotic-descriptors-validatedfield-set)
-    - [`protocols`](#sample-package-exotic-protocols)
-      - [`Loggable`](#sample-package-exotic-protocols-loggable)
-        - [`log_format`](#sample-package-exotic-protocols-loggable-log-format)
-    - [`deep`](#sample-package-exotic-deep)
-      - [`recursive`](#sample-package-exotic-deep-recursive)
-        - [`Serializable`](#sample-package-exotic-deep-recursive-serializable)
-          - [`__init__`](#sample-package-exotic-deep-recursive-serializable-init)
-          - [`serialize`](#sample-package-exotic-deep-recursive-serializable-serialize)
+- 🅼 [sample_package](#sample_package)
+- 🅼 [sample_package.core](#sample_package-core)
+- 🅼 [sample_package.exotic](#sample_package-exotic)
+- 🅼 [sample_package.exotic.advanced_types](#sample_package-exotic-advanced_types)
+- 🅼 [sample_package.exotic.deep](#sample_package-exotic-deep)
+- 🅼 [sample_package.exotic.deep.recursive](#sample_package-exotic-deep-recursive)
+- 🅼 [sample_package.exotic.descriptors](#sample_package-exotic-descriptors)
+- 🅼 [sample_package.exotic.protocols](#sample_package-exotic-protocols)
+- 🅼 [sample_package.models](#sample_package-models)
+- 🅼 [sample_package.utils](#sample_package-utils)
 
-<a id="sample-package"></a>
-# `sample_package`
+<a name="sample_package"></a>
+## 🅼 sample_package
 
-Sample package for testing docstring to markdown conversion.
+Sample package for testing docstring to markdown conversion\.
 
 This package contains various Python constructs with different docstring formats
-to test the python-docstring-markdown package.
+to test the python-docstring-markdown package\.
 
 Available modules:
     - core: Core functionality with Google-style docstrings
     - utils: Utility functions with ReST-style docstrings
     - models: Data models with Numpydoc-style docstrings
 
-**Exports:**
+- **[Exports](#sample_package-exports)**
 
-- `core`
-- `utils`
-- `models`
+<a name="sample_package-exports"></a>
+### Exports
 
-<a id="sample-package-core"></a>
-## `core`
+- 🅼 [`core`](#sample_package-core)
+- 🅼 [`utils`](#sample_package-utils)
+- 🅼 [`models`](#sample_package-models)
+<a name="sample_package-core"></a>
+## 🅼 sample_package.core
 
-Core functionality module using Google-style docstrings.
+Core functionality module using Google-style docstrings\.
 
 This module demonstrates Google-style docstrings with various Python constructs
-including nested classes, methods, and functions.
+including nested classes, methods, and functions\.
 
-<a id="sample-package-core-dataprocessor"></a>
-### `DataProcessor`
+- **Functions:**
+  - 🅵 [batch_process](#sample_package-core-batch_process)
+- **Classes:**
+  - 🅲 [DataProcessor](#sample_package-core-DataProcessor)
+    - 🅲 [Config](#sample_package-core-DataProcessor-Config)
 
-Main data processing class.
+### Functions
 
-This class demonstrates nested class definitions and various method types.
-
-<a id="sample-package-core-dataprocessor-init"></a>
-#### `__init__`
-
-```python
-def __init__(self, name: str, config: Optional[Dict[str, Any]]):
-```
-
-Initialize the DataProcessor.
-
-**Args:**
-
-- `name`: Name of the processor
-- `config`: Optional configuration dictionary
-
-<a id="sample-package-core-dataprocessor-config"></a>
-#### `Config`
-
-Nested configuration class.
-
-This demonstrates nested class documentation.
-
-<a id="sample-package-core-dataprocessor-config-init"></a>
-##### `__init__`
-
-```python
-def __init__(self):
-```
-
-Initialize Config object.
-
-<a id="sample-package-core-dataprocessor-config-update"></a>
-##### `update`
-
-```python
-def update(self, settings: Dict[str, Any]) -> None:
-```
-
-Update configuration settings.
-
-**Args:**
-
-- `settings`: Dictionary of settings to update
-
-<a id="sample-package-core-dataprocessor-process"></a>
-#### `process`
-
-```python
-def process(self, data: List[Any]) -> List[Any]:
-```
-
-Process the input data.
-
-**Args:**
-
-- `data`: List of data items to process
-
-**Returns:** Processed data items
-
-**Raises:**
-
-- (*ValueError*) If data is empty
-
-<a id="sample-package-core-batch-process"></a>
-### `batch_process`
+<a name="sample_package-core-batch_process"></a>
+### 🅵 sample_package.core.batch_process
 
 ```python
 def batch_process(processor: DataProcessor, items: List[Any]) -> Dict[str, List[Any]]:
 ```
 
-Batch process items using a DataProcessor.
+Batch process items using a DataProcessor\.
 
-This is a module-level function demonstrating Google-style docstrings.
+This is a module-level function demonstrating Google-style docstrings\.
 
-**Args:**
+**Parameters:**
 
-- `processor`: DataProcessor instance to use
-- `items`: List of items to process
+- **processor**: DataProcessor instance to use
+- **items**: List of items to process
 
-**Returns:** (*Dictionary containing*) - 'processed': List of processed items
+**Returns:**
+
+- `Dictionary containing`: - 'processed': List of processed items
 - 'errors': List of items that failed processing
 
-<a id="sample-package-models"></a>
-## `models`
+### Classes
 
-Models module using Numpydoc-style docstrings.
-
-This module demonstrates Numpydoc-style docstrings with data model classes.
-
-<a id="sample-package-models-basemodel"></a>
-### `BaseModel`
-
-Base model class for all data models.
-
-**Args:**
-
-- `id` (*str*): Unique identifier for the model
-- `created_at` (*datetime*): Timestamp when the model was created
-
-<a id="sample-package-models-basemodel-to-dict"></a>
-#### `to_dict`
+<a name="sample_package-core-DataProcessor"></a>
+### 🅲 sample_package.core.DataProcessor
 
 ```python
-def to_dict(self) -> Dict[str, Any]:
+class DataProcessor:
 ```
 
-Convert model to dictionary.
+Main data processing class\.
 
-**Returns:** (*Dict[str, Any]*) Dictionary representation of the model
+This class demonstrates nested class definitions and various method types\.
 
-<a id="sample-package-models-user"></a>
-### `User`
+**Attributes:**
 
-User model representing system users.
+- **name**: The name of the processor
+- **config**: Configuration dictionary
 
-**Args:**
+**Functions:**
 
-- `id` (*str*): Unique identifier for the user
-- `username` (*str*): User's username
-- `email` (*str*): User's email address
-- `active` (*bool*): Whether the user is active, by default True
-
-<a id="sample-package-models-user-init"></a>
-#### `__init__`
+<a name="sample_package-core-DataProcessor-__init__"></a>
+#### 🅵 sample_package.core.DataProcessor.__init__
 
 ```python
-def __init__(self, id: str, username: str, email: str, active: bool):
+def __init__(self, name: str, config: Optional[Dict[str, Any]] = None):
 ```
 
-<a id="sample-package-models-user-to-dict"></a>
-#### `to_dict`
+Initialize the DataProcessor\.
+
+**Parameters:**
+
+- **name**: Name of the processor
+- **config**: Optional configuration dictionary
+<a name="sample_package-core-DataProcessor-process"></a>
+#### 🅵 sample_package.core.DataProcessor.process
 
 ```python
-def to_dict(self) -> Dict[str, Any]:
+def process(self, data: List[Any]) -> List[Any]:
 ```
 
-Convert user to dictionary.
+Process the input data\.
 
-**Returns:** (*Dict[str, Any]*) Dictionary containing all user fields
+**Parameters:**
 
-<a id="sample-package-utils"></a>
-## `utils`
+- **data**: List of data items to process
 
-Utility functions module using ReST-style docstrings.
+**Returns:**
 
-This module demonstrates ReST-style docstrings with various utility functions.
-
-<a id="sample-package-utils-load-json"></a>
-### `load_json`
-
-```python
-def load_json(filepath: str) -> Dict[str, Any]:
-```
-
-Load and parse a JSON file.
-
-**Args:**
-
-- `filepath` (*str*): Path to the JSON file
-
-**Returns:** (*dict*) Parsed JSON content as a dictionary
+- Processed data items
 
 **Raises:**
 
-- (*FileNotFoundError*) If the file doesn't exist
-- (*json.JSONDecodeError*) If the file contains invalid JSON
+- **ValueError**: If data is empty
 
-<a id="sample-package-utils-validate-data"></a>
-### `validate_data`
-
-```python
-def validate_data(data: Any, schema: Dict[str, Any]) -> List[str]:
-```
-
-Validate data against a schema.
-
-This function demonstrates multi-paragraph ReST docstrings.
-
-The schema should be a dictionary defining the expected structure
-and types of the data.
-
-**Args:**
-
-- `data`: Data to validate
-- `schema`: Schema to validate against
-
-**Returns:** List of validation errors, empty if valid
-
-<a id="sample-package-utils-validationerror"></a>
-### `ValidationError`
-
-Custom exception for validation errors.
-
-**Args:**
-
-- `message`: Error message
-- `errors`: List of specific validation errors
-Example::
-
-    raise ValidationError("Invalid data", ["field1 is required"])
-
-<a id="sample-package-utils-validationerror-init"></a>
-#### `__init__`
+<a name="sample_package-core-DataProcessor-Config"></a>
+### 🅲 sample_package.core.DataProcessor.Config
 
 ```python
-def __init__(self, message: str, errors: List[str]):
+class Config:
 ```
 
-Initialize ValidationError.
+Nested configuration class\.
 
-**Args:**
+This demonstrates nested class documentation\.
 
-- `message`: Error message
-- `errors`: List of validation errors
+**Functions:**
 
-<a id="sample-package-exotic"></a>
-## `exotic`
+<a name="sample_package-core-DataProcessor-Config-__init__"></a>
+#### 🅵 sample_package.core.DataProcessor.Config.__init__
 
-Exotic module demonstrating advanced Python features and docstring styles.
+```python
+def __init__(self):
+```
+
+Initialize Config object\.
+<a name="sample_package-core-DataProcessor-Config-update"></a>
+#### 🅵 sample_package.core.DataProcessor.Config.update
+
+```python
+def update(self, settings: Dict[str, Any]) -> None:
+```
+
+Update configuration settings\.
+
+**Parameters:**
+
+- **settings**: Dictionary of settings to update
+<a name="sample_package-exotic"></a>
+## 🅼 sample_package.exotic
+
+Exotic module demonstrating advanced Python features and docstring styles\.
 
 This module showcases various Python features including:
     - Type hints with Protocol and TypeVar
     - Async functions and context managers
     - Descriptors and metaclasses
-    - Mixed docstring styles (Google, ReST, and Numpydoc)
+    - Mixed docstring styles \(Google, ReST, and Numpydoc\)
 
-**Exports:**
+- **[Exports](#sample_package-exotic-exports)**
 
-- `advanced_types`
-- `protocols`
-- `descriptors`
+<a name="sample_package-exotic-exports"></a>
+### Exports
 
-<a id="sample-package-exotic-advanced-types"></a>
-### `advanced_types`
+- 🅼 [`advanced_types`](#sample_package-exotic-advanced_types)
+- 🅼 [`protocols`](#sample_package-exotic-protocols)
+- 🅼 [`descriptors`](#sample_package-exotic-descriptors)
+<a name="sample_package-exotic-advanced_types"></a>
+## 🅼 sample_package.exotic.advanced_types
 
-Advanced type hints and generic types demonstration.
+Advanced type hints and generic types demonstration\.
 
 This module uses various type hints and generic types to showcase
-complex typing scenarios.
+complex typing scenarios\.
 
-<a id="sample-package-exotic-advanced-types-serializable"></a>
-### `Serializable`
+- **Constants:**
+  - 🆅 [T](#sample_package-exotic-advanced_types-T)
+  - 🆅 [S](#sample_package-exotic-advanced_types-S)
+- **Classes:**
+  - 🅲 [Serializable](#sample_package-exotic-advanced_types-Serializable)
 
-A generic serializable container.
+### Constants
+
+<a name="sample_package-exotic-advanced_types-T"></a>
+### 🆅 sample_package.exotic.advanced_types.T
+
+```python
+T = TypeVar('T')
+```
+<a name="sample_package-exotic-advanced_types-S"></a>
+### 🆅 sample_package.exotic.advanced_types.S
+
+```python
+S = TypeVar('S', bound='Serializable')
+```
+
+### Classes
+
+<a name="sample_package-exotic-advanced_types-Serializable"></a>
+### 🅲 sample_package.exotic.advanced_types.Serializable
+
+```python
+class Serializable(Generic[T]):
+```
+
+A generic serializable container\.
 
 Type Parameters
 --------------
 T
     The type of value being stored
 
-<a id="sample-package-exotic-advanced-types-serializable-init"></a>
-#### `__init__`
+**Attributes:**
+
+- **value** (`T`): The contained value
+- **created_at** (`datetime`): Timestamp of creation
+
+**Functions:**
+
+<a name="sample_package-exotic-advanced_types-Serializable-__init__"></a>
+#### 🅵 sample_package.exotic.advanced_types.Serializable.__init__
 
 ```python
 def __init__(self, value: T):
 ```
-
-<a id="sample-package-exotic-advanced-types-serializable-serialize"></a>
-#### `serialize`
+<a name="sample_package-exotic-advanced_types-Serializable-serialize"></a>
+#### 🅵 sample_package.exotic.advanced_types.Serializable.serialize
 
 ```python
 def serialize(self) -> dict:
 ```
 
-Convert the container to a dictionary.
+Convert the container to a dictionary\.
 
-**Returns:** (*dict*) A dictionary containing the value and metadata
+**Returns:**
 
-<a id="sample-package-exotic-descriptors"></a>
-### `descriptors`
+- `dict`: A dictionary containing the value and metadata
+<a name="sample_package-exotic-deep"></a>
+## 🅼 sample_package.exotic.deep
+<a name="sample_package-exotic-deep-recursive"></a>
+## 🅼 sample_package.exotic.deep.recursive
 
-Descriptors and metaclasses demonstration.
+A little recursive module using ReST-style docstrings\.
 
-This module shows how to use descriptors and metaclasses
-with proper documentation.
+This module demonstrates ReST-style docstrings with various utility functions\.
 
-<a id="sample-package-exotic-descriptors-validatedfield"></a>
-### `ValidatedField`
+- **Classes:**
+  - 🅲 [Serializable](#sample_package-exotic-deep-recursive-Serializable)
 
-A descriptor that validates its values.
+### Classes
 
-**Args:**
-
-- `validator` (*callable*): A function that takes a value and returns True if valid
-- `error_message` (*str*): Message to display when validation fails
-
-<a id="sample-package-exotic-descriptors-validatedfield-init"></a>
-#### `__init__`
+<a name="sample_package-exotic-deep-recursive-Serializable"></a>
+### 🅲 sample_package.exotic.deep.recursive.Serializable
 
 ```python
-def __init__(self, validator, error_message):
+class Serializable:
 ```
 
-<a id="sample-package-exotic-descriptors-validatedfield-get"></a>
-#### `__get__`
+**Functions:**
 
-```python
-def __get__(self, instance, owner):
-```
-
-Get the field value.
-
-**Args:**
-
-- `instance`: The instance being accessed
-- `owner`: The owner class
-
-**Returns:** The field value
-
-<a id="sample-package-exotic-descriptors-validatedfield-set"></a>
-#### `__set__`
-
-```python
-def __set__(self, instance, value):
-```
-
-Set and validate the field value.
-
-**Args:**
-
-- `instance`: The instance being modified
-- `value`: The new value to set
-
-**Raises:**
-
-- (*ValueError*) If the value fails validation
-
-<a id="sample-package-exotic-protocols"></a>
-### `protocols`
-
-Protocol and structural subtyping examples.
-
-This module demonstrates the use of Protocol for structural subtyping
-and abstract base classes.
-
-<a id="sample-package-exotic-protocols-loggable"></a>
-### `Loggable`
-
-Protocol for objects that can be logged.
-
-Args:
-    None
-
-Returns:
-    str: A string representation suitable for logging
-
-Example:
-    >>> class MyClass(Loggable):
-    ...     def log_format(self) -> str:
-    ...         return "MyClass instance"
-
-<a id="sample-package-exotic-protocols-loggable-log-format"></a>
-#### `log_format`
-
-```python
-def log_format(self) -> str:
-```
-
-Format the object for logging.
-
-**Returns:** A string representation of the object
-
-<a id="sample-package-exotic-deep"></a>
-### `deep`
-
-
-<a id="sample-package-exotic-deep-recursive"></a>
-#### `recursive`
-
-A little recursive module using ReST-style docstrings.
-
-This module demonstrates ReST-style docstrings with various utility functions.
-
-<a id="sample-package-exotic-deep-recursive-serializable"></a>
-### `Serializable`
-
-<a id="sample-package-exotic-deep-recursive-serializable-init"></a>
-#### `__init__`
+<a name="sample_package-exotic-deep-recursive-Serializable-__init__"></a>
+#### 🅵 sample_package.exotic.deep.recursive.Serializable.__init__
 
 ```python
 def __init__(self, data: Dict[str, Any]) -> None:
 ```
 
-Initialize a Serializable object.
+Initialize a Serializable object\.
 
-**Args:**
+**Parameters:**
 
-- `data`: Data to serialize
-
-<a id="sample-package-exotic-deep-recursive-serializable-serialize"></a>
-#### `serialize`
+- **data**: Data to serialize
+<a name="sample_package-exotic-deep-recursive-Serializable-serialize"></a>
+#### 🅵 sample_package.exotic.deep.recursive.Serializable.serialize
 
 ```python
 def serialize(self) -> Dict[str, Any]:
 ```
 
-Serialize the object to a dictionary.
+Serialize the object to a dictionary\.
 
-**Returns:** (*Dict[str, Any]*) Dictionary representation of the object
+**Returns:**
+
+- `Dict[str, Any]`: Dictionary representation of the object
+<a name="sample_package-exotic-descriptors"></a>
+## 🅼 sample_package.exotic.descriptors
+
+Descriptors and metaclasses demonstration\.
+
+This module shows how to use descriptors and metaclasses
+with proper documentation\.
+
+- **Classes:**
+  - 🅲 [ValidatedField](#sample_package-exotic-descriptors-ValidatedField)
+
+### Classes
+
+<a name="sample_package-exotic-descriptors-ValidatedField"></a>
+### 🅲 sample_package.exotic.descriptors.ValidatedField
+
+```python
+class ValidatedField:
+```
+
+A descriptor that validates its values\.
+
+**Parameters:**
+
+- **validator** (`callable`): A function that takes a value and returns True if valid
+- **error_message** (`str`): Message to display when validation fails
+
+**Functions:**
+
+<a name="sample_package-exotic-descriptors-ValidatedField-__init__"></a>
+#### 🅵 sample_package.exotic.descriptors.ValidatedField.__init__
+
+```python
+def __init__(self, validator, error_message):
+```
+<a name="sample_package-exotic-descriptors-ValidatedField-__get__"></a>
+#### 🅵 sample_package.exotic.descriptors.ValidatedField.__get__
+
+```python
+def __get__(self, instance, owner):
+```
+
+Get the field value\.
+
+**Parameters:**
+
+- **instance**: The instance being accessed
+- **owner**: The owner class
+
+**Returns:**
+
+- The field value
+<a name="sample_package-exotic-descriptors-ValidatedField-__set__"></a>
+#### 🅵 sample_package.exotic.descriptors.ValidatedField.__set__
+
+```python
+def __set__(self, instance, value):
+```
+
+Set and validate the field value\.
+
+**Parameters:**
+
+- **instance**: The instance being modified
+- **value**: The new value to set
+
+**Raises:**
+
+- **ValueError**: If the value fails validation
+<a name="sample_package-exotic-protocols"></a>
+## 🅼 sample_package.exotic.protocols
+
+Protocol and structural subtyping examples\.
+
+This module demonstrates the use of Protocol for structural subtyping
+and abstract base classes\.
+
+- **Classes:**
+  - 🅲 [Loggable](#sample_package-exotic-protocols-Loggable)
+
+### Classes
+
+<a name="sample_package-exotic-protocols-Loggable"></a>
+### 🅲 sample_package.exotic.protocols.Loggable
+
+```python
+class Loggable(Protocol):
+```
+
+Protocol for objects that can be logged\.
+
+**Functions:**
+
+<a name="sample_package-exotic-protocols-Loggable-log_format"></a>
+#### 🅵 sample_package.exotic.protocols.Loggable.log_format
+
+```python
+def log_format(self) -> str:
+```
+
+Format the object for logging\.
+
+**Returns:**
+
+- A string representation of the object
+<a name="sample_package-models"></a>
+## 🅼 sample_package.models
+
+Models module using Numpydoc-style docstrings\.
+
+This module demonstrates Numpydoc-style docstrings with data model classes\.
+
+- **Classes:**
+  - 🅲 [BaseModel](#sample_package-models-BaseModel)
+  - 🅲 [User](#sample_package-models-User)
+
+### Classes
+
+<a name="sample_package-models-BaseModel"></a>
+### 🅲 sample_package.models.BaseModel
+
+```python
+class BaseModel:
+```
+
+Base model class for all data models\.
+
+**Attributes:**
+
+- **id** (`str`): Unique identifier
+- **created_at** (`datetime`): Creation timestamp
+
+**Functions:**
+
+<a name="sample_package-models-BaseModel-to_dict"></a>
+#### 🅵 sample_package.models.BaseModel.to_dict
+
+```python
+def to_dict(self) -> Dict[str, Any]:
+```
+
+Convert model to dictionary\.
+
+**Returns:**
+
+- `Dict[str, Any]`: Dictionary representation of the model
+<a name="sample_package-models-User"></a>
+### 🅲 sample_package.models.User
+
+```python
+class User(BaseModel):
+```
+
+User model representing system users\.
+
+**Functions:**
+
+<a name="sample_package-models-User-__init__"></a>
+#### 🅵 sample_package.models.User.__init__
+
+```python
+def __init__(self, id: str, username: str, email: str, active: bool = True):
+```
+
+**Parameters:**
+
+- **id** (`str`): Unique identifier for the user
+- **username** (`str`): User's username
+- **email** (`str`): User's email address
+- **active** (`bool`) (default: `True`): Whether the user is active, by default True
+
+**Attributes:**
+
+- **username** (`str`): User's username
+- **email** (`str`): User's email address
+- **active** (`bool`): User's active status
+<a name="sample_package-models-User-to_dict"></a>
+#### 🅵 sample_package.models.User.to_dict
+
+```python
+def to_dict(self) -> Dict[str, Any]:
+```
+
+Convert user to dictionary\.
+
+**Returns:**
+
+- `Dict[str, Any]`: Dictionary containing all user fields
+<a name="sample_package-utils"></a>
+## 🅼 sample_package.utils
+
+Utility functions module using ReST-style docstrings\.
+
+This module demonstrates ReST-style docstrings with various utility functions\.
+
+- **Functions:**
+  - 🅵 [load_json](#sample_package-utils-load_json)
+  - 🅵 [validate_data](#sample_package-utils-validate_data)
+- **Classes:**
+  - 🅲 [ValidationError](#sample_package-utils-ValidationError)
+
+### Functions
+
+<a name="sample_package-utils-load_json"></a>
+### 🅵 sample_package.utils.load_json
+
+```python
+def load_json(filepath: str) -> Dict[str, Any]:
+```
+
+Load and parse a JSON file\.
+
+**Parameters:**
+
+- **filepath** (`str`): Path to the JSON file
+
+**Returns:**
+
+- `dict`: Parsed JSON content as a dictionary
+
+**Raises:**
+
+- **FileNotFoundError**: If the file doesn't exist
+- **json.JSONDecodeError**: If the file contains invalid JSON
+<a name="sample_package-utils-validate_data"></a>
+### 🅵 sample_package.utils.validate_data
+
+```python
+def validate_data(data: Any, schema: Dict[str, Any]) -> List[str]:
+```
+
+Validate data against a schema\.
+
+This function demonstrates multi-paragraph ReST docstrings\.
+
+The schema should be a dictionary defining the expected structure
+and types of the data\.
+
+**Parameters:**
+
+- **data**: Data to validate
+- **schema**: Schema to validate against
+
+**Returns:**
+
+- List of validation errors, empty if valid
+
+### Classes
+
+<a name="sample_package-utils-ValidationError"></a>
+### 🅲 sample_package.utils.ValidationError
+
+```python
+class ValidationError(Exception):
+```
+
+Custom exception for validation errors\.
+
+**Parameters:**
+
+- **message**: Error message
+- **errors**: List of specific validation errors
+Example::
+
+    raise ValidationError\("Invalid data", \["field1 is required"\]\)
+
+**Functions:**
+
+<a name="sample_package-utils-ValidationError-__init__"></a>
+#### 🅵 sample_package.utils.ValidationError.__init__
+
+```python
+def __init__(self, message: str, errors: List[str]):
+```
+
+Initialize ValidationError\.
+
+**Parameters:**
+
+- **message**: Error message
+- **errors**: List of validation errors

--- a/tests/sample_package/exotic/advanced_types.py
+++ b/tests/sample_package/exotic/advanced_types.py
@@ -9,6 +9,9 @@ from typing import Generic, TypeVar
 
 T = TypeVar("T")
 S = TypeVar("S", bound="Serializable")
+"""
+Serializable container type.
+"""
 
 
 class Serializable(Generic[T]):

--- a/tests/sample_package/exotic/protocols.py
+++ b/tests/sample_package/exotic/protocols.py
@@ -12,12 +12,6 @@ from typing import Protocol, runtime_checkable
 class Loggable(Protocol):
     """Protocol for objects that can be logged.
 
-    Args:
-        None
-
-    Returns:
-        str: A string representation suitable for logging
-
     Example:
         >>> class MyClass(Loggable):
         ...     def log_format(self) -> str:

--- a/tests/sample_package/models.py
+++ b/tests/sample_package/models.py
@@ -12,13 +12,6 @@ from typing import Any, Dict
 class BaseModel:
     """Base model class for all data models.
 
-    Parameters
-    ----------
-    id : str
-        Unique identifier for the model
-    created_at : datetime
-        Timestamp when the model was created
-
     Attributes
     ----------
     id : str
@@ -44,26 +37,6 @@ class BaseModel:
 class User(BaseModel):
     """User model representing system users.
 
-    Parameters
-    ----------
-    id : str
-        Unique identifier for the user
-    username : str
-        User's username
-    email : str
-        User's email address
-    active : bool, optional
-        Whether the user is active, by default True
-
-    Attributes
-    ----------
-    username : str
-        User's username
-    email : str
-        User's email address
-    active : bool
-        User's active status
-
     Examples
     --------
     >>> user = User("123", "johndoe", "john@example.com")
@@ -72,6 +45,27 @@ class User(BaseModel):
     """
 
     def __init__(self, id: str, username: str, email: str, active: bool = True):
+        """
+        Parameters
+        ----------
+        id : str
+            Unique identifier for the user
+        username : str
+            User's username
+        email : str
+            User's email address
+        active : bool, optional
+            Whether the user is active, by default True
+
+        Attributes
+        ----------
+        username : str
+            User's username
+        email : str
+            User's email address
+        active : bool
+            User's active status
+        """
         super().__init__(id)
         self.username = username
         self.email = email

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,9 +1,11 @@
 import difflib
 import os
+from pathlib import Path
 
 import pytest
 
-from python_docstring_markdown import crawl
+from python_docstring_markdown import crawl_package
+from python_docstring_markdown.generate import MarkdownRenderer
 
 
 @pytest.fixture(scope="session")
@@ -25,12 +27,14 @@ def docs_file(test_dir):
 
 
 @pytest.fixture(scope="session")
-def generated_markdown(sample_package_dir, docs_file):
+def generated_markdown(sample_package_dir):
     """Generate and load the documentation content."""
     # Generate the documentation
-    content = crawl(sample_package_dir)
+    package = crawl_package(Path(sample_package_dir))
+    renderer = MarkdownRenderer()
+    markdown_output = renderer.render(package)
 
-    yield content
+    yield markdown_output
 
 
 def test_generated_markdown(generated_markdown, docs_file):
@@ -46,5 +50,6 @@ def test_generated_markdown(generated_markdown, docs_file):
                 generated_markdown.splitlines(keepends=True),
             )
         )
-        print("".join(diff), end="")
+        #print("".join(diff), end="")
+        print(generated_markdown)
         raise AssertionError("Generated markdown does not match expected content.")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -31,9 +31,9 @@ def generated_markdown(sample_package_dir):
     """Generate and load the documentation content."""
     package = crawl_package(Path(sample_package_dir))
     renderer = MarkdownRenderer()
-    markdown_output = renderer.render(package, True)
+    markdown_output = renderer.render(package)
 
-    yield "\n".join(markdown_output)
+    yield "\n".join(markdown_output or [])
 
 
 def test_generated_markdown(generated_markdown, docs_file):

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -29,7 +29,6 @@ def docs_file(test_dir):
 @pytest.fixture(scope="session")
 def generated_markdown(sample_package_dir):
     """Generate and load the documentation content."""
-    # Generate the documentation
     package = crawl_package(Path(sample_package_dir))
     renderer = MarkdownRenderer()
     markdown_output = renderer.render(package)
@@ -50,6 +49,6 @@ def test_generated_markdown(generated_markdown, docs_file):
                 generated_markdown.splitlines(keepends=True),
             )
         )
-        #print("".join(diff), end="")
+        # print("".join(diff), end="")
         print(generated_markdown)
         raise AssertionError("Generated markdown does not match expected content.")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -29,11 +29,17 @@ def docs_file(test_dir):
 @pytest.fixture(scope="session")
 def generated_markdown(sample_package_dir):
     """Generate and load the documentation content."""
-    package = crawl_package(Path(sample_package_dir))
-    renderer = MarkdownRenderer()
-    markdown_output = renderer.render(package)
+    # Creat a temporary file path
+    import tempfile
 
-    yield "\n".join(markdown_output or [])
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        tmp_docs_file = Path(tmp_file.name)
+        package = crawl_package(Path(sample_package_dir))
+        renderer = MarkdownRenderer()
+        renderer.render(package, tmp_docs_file)
+        generated_markdown = tmp_docs_file.read_text(encoding="utf8")
+
+    yield generated_markdown
 
 
 def test_generated_markdown(generated_markdown, docs_file):
@@ -49,6 +55,5 @@ def test_generated_markdown(generated_markdown, docs_file):
                 generated_markdown.splitlines(keepends=True),
             )
         )
-        # print("".join(diff), end="")
-        print(generated_markdown)
+        print("\n".join(diff))
         raise AssertionError("Generated markdown does not match expected content.")

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -31,7 +31,7 @@ def generated_markdown(sample_package_dir):
     """Generate and load the documentation content."""
     package = crawl_package(Path(sample_package_dir))
     renderer = MarkdownRenderer()
-    markdown_output = renderer.render_package(package)
+    markdown_output = renderer.render(package, True)
 
     yield "\n".join(markdown_output)
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -27,14 +27,9 @@ def docs_file(test_dir):
 
 
 @pytest.fixture(scope="session")
-def package(sample_package_dir):
-    """Crawl the package and return the resulting Package object."""
-    return crawl_package(Path(sample_package_dir))
-
-
-@pytest.fixture(scope="session")
-def generated_markdown(package):
+def generated_markdown(sample_package_dir):
     """Generate and load the documentation content."""
+    package = crawl_package(Path(sample_package_dir))
     renderer = MarkdownRenderer()
     markdown_output = renderer.render(package, True)
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -27,9 +27,14 @@ def docs_file(test_dir):
 
 
 @pytest.fixture(scope="session")
-def generated_markdown(sample_package_dir):
+def package(sample_package_dir):
+    """Crawl the package and return the resulting Package object."""
+    return crawl_package(Path(sample_package_dir))
+
+
+@pytest.fixture(scope="session")
+def generated_markdown(package):
     """Generate and load the documentation content."""
-    package = crawl_package(Path(sample_package_dir))
     renderer = MarkdownRenderer()
     markdown_output = renderer.render(package, True)
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -31,9 +31,9 @@ def generated_markdown(sample_package_dir):
     """Generate and load the documentation content."""
     package = crawl_package(Path(sample_package_dir))
     renderer = MarkdownRenderer()
-    markdown_output = renderer.render(package)
+    markdown_output = renderer.render_package(package)
 
-    yield markdown_output
+    yield "\n".join(markdown_output)
 
 
 def test_generated_markdown(generated_markdown, docs_file):


### PR DESCRIPTION
This PR adds the ability to output to multiple files.

If `output_path` points to a directory instead of a file, the renderer will now output one file per-module in a flat structure like so:

```
index.md
package_name.md
package_name.foo.md
package_name.foo.bar.md
```

The `index.md` file contains a table of contents with links to each package .md file.

I also updated the Markdown styling quite a bit to make it easier to read.

Fixes #2