### PR TITLE
Support parsing of `.pyi` stub files

### DIFF
--- a/src/python_docstring_markdown/generate.py
+++ b/src/python_docstring_markdown/generate.py
@@ -338,24 +338,26 @@ def parse_module_submodules(
     include_private: bool,
 ) -> None:
     """Parse submodules of a module."""
-    for file_path in file_path.parent.iterdir():
-        init_py = file_path / "__init__.py"
-        if init_py.is_file():
+    for entry in file_path.parent.iterdir():
+        init_py = entry / "__init__.py"
+        init_pyi = entry / "__init__.pyi"
+        if init_py.is_file() or init_pyi.is_file():
+            init_file = init_py if init_py.is_file() else init_pyi
             submodule = parse_module(
-                init_py,
-                f"{module.fully_qualified_name}.{file_path.name}",
+                init_file,
+                f"{module.fully_qualified_name}.{entry.name}",
                 include_private,
             )
             module.submodules.append(submodule)
-        elif file_path.suffix == ".py" and file_path.stem != "__init__":
+        elif entry.suffix in {".py", ".pyi"} and entry.stem != "__init__":
             if (
                 not include_private
-                and file_path.name.startswith("_")
-                and not file_path.name.startswith("__")
+                and entry.name.startswith("_")
+                and not entry.name.startswith("__")
             ):
                 continue
             submodule = parse_module(
-                file_path,
+                entry,
                 f"{module.fully_qualified_name}",
                 include_private,
             )
@@ -394,7 +396,7 @@ def parse_module(
 
 
 def crawl_package(package_path: Path, include_private: bool = False) -> Package:
-    """Recursively crawl the package directory, parsing each .py file as a Module.
+    """Recursively crawl the package directory, parsing each .py or .pyi file as a Module.
 
     If include_private is False, items (functions, classes, constants, submodules)
     whose names start with a single underscore (but not dunder names like __init__)
@@ -405,7 +407,9 @@ def crawl_package(package_path: Path, include_private: bool = False) -> Package:
         path=package_path, name=pkg_name, fully_qualified_name=pkg_name, modules=[]
     )
     modules = []
-    for file_path in package_path.glob("*.py"):
+    for file_path in sorted(
+        list(package_path.glob("*.py")) + list(package_path.glob("*.pyi"))
+    ):
         if (
             not include_private
             and file_path.stem.startswith("_")

--- a/tests/data/DOCUMENTATION.md
+++ b/tests/data/DOCUMENTATION.md
@@ -11,6 +11,7 @@
 - 🅼 [sample\_package\.exotic\.descriptors](#sample_package-exotic-descriptors)
 - 🅼 [sample\_package\.exotic\.protocols](#sample_package-exotic-protocols)
 - 🅼 [sample\_package\.models](#sample_package-models)
+- 🅼 [sample\_package\.stub](#sample_package-stub)
 - 🅼 [sample\_package\.utils](#sample_package-utils)
 
 <a name="sample_package"></a>
@@ -482,6 +483,24 @@ Convert user to dictionary\.
 **Returns:**
 
 - `Dict[str, Any]`: Dictionary containing all user fields
+<a name="sample_package-stub"></a>
+## 🅼 sample\_package\.stub
+
+Stub module for testing \.pyi file support\.
+
+- **Functions:**
+  - 🅵 [stub\_function](#sample_package-stub-stub_function)
+
+### Functions
+
+<a name="sample_package-stub-stub_function"></a>
+### 🅵 sample\_package\.stub\.stub\_function
+
+```python
+def stub_function(x: int) -> str:
+```
+
+Return the string representation of \`\`x\`\`\.
 <a name="sample_package-utils"></a>
 ## 🅼 sample\_package\.utils
 

--- a/tests/sample_package/stub.pyi
+++ b/tests/sample_package/stub.pyi
@@ -1,0 +1,5 @@
+"""Stub module for testing .pyi file support."""
+
+def stub_function(x: int) -> str:
+    """Return the string representation of ``x``."""
+    ...


### PR DESCRIPTION
## Summary
- Handle `.pyi` files when crawling packages and submodules
- Add stub module to test `.pyi` support

## Testing
- `pdm run style`
- `pdm run test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a725b61c83299ebec7f666427a0e